### PR TITLE
Some example updates to avoid gotchas for the unwary

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,22 @@ go get github.com/bbockelm/golang-htcondor
 
 ```go
 import "github.com/bbockelm/golang-htcondor"
+import "context"
+import "log"
+
+ctx := context.Background()
 
 // Create a collector instance
-collector := htcondor.NewCollector("collector.example.com", 9618)
+collector := htcondor.NewCollector("collector.example.com:9618")
 
 // Query for schedd ads
 ads, err := collector.QueryAds(ctx, "ScheddAd", "")
+if err != nil {
+    log.Fatal(err)
+}
+
+// Query for schedd ads of a specific schedd
+ads, err := collector.QueryAds(ctx, "ScheddAd", `Machine=="schedd_name"`)
 if err != nil {
     log.Fatal(err)
 }


### PR DESCRIPTION
- ctx needs to be an initialized context
- htcondor.NewCollector() requires the port as part of the string
- collector.QueryAds() takes a constraint as its third argument, which must be a classad expression