### PR TITLE
Add support for startup limits in the library

### DIFF
--- a/design_notes/STARTUP_LIMITS.md
+++ b/design_notes/STARTUP_LIMITS.md
@@ -1,0 +1,313 @@
+# HTCondor Startup Limits
+
+Startup limits allow you to control the rate at which jobs matching specific criteria can start in an HTCondor schedd. This is useful for:
+
+- **Rate limiting expensive resources** (GPU jobs, high-memory jobs)
+- **Managing cluster load** during peak times
+- **Preventing resource exhaustion** from sudden job surges
+- **Monitoring job patterns** without enforcement
+- **Variable cost allocation** (e.g., large jobs count as multiple small jobs)
+
+## Features
+
+- **Expression-based matching**: Use ClassAd expressions to target specific job types
+- **Token bucket algorithm**: Allows bursts while maintaining average rate
+- **Variable cost**: Jobs can consume different numbers of tokens based on their attributes
+- **Temporary burst capacity**: Allow temporary spikes beyond the base rate
+- **Statistics tracking**: Monitor allowed, skipped, and ignored jobs
+- **Expiring limits**: Automatically remove limits after a specified time
+- **Unlimited monitoring**: Set rate to 0 to track statistics without enforcement
+
+## Quick Start
+
+```go
+import "github.com/bbockelm/golang-htcondor"
+
+// Create a schedd connection
+schedd := htcondor.NewSchedd("", "schedd.example.com:9618")
+
+// Create a GPU job rate limit: max 10 GPU jobs per minute
+req := &htcondor.StartupLimitRequest{
+    Tag:        "gpu_limit",
+    Name:       "GPU Job Rate Limit",
+    Expression: "RequestGpus > 0",
+    RateCount:  10,
+    RateWindow: 60,
+    Expiration: 3600, // expires in 1 hour
+}
+
+uuid, err := schedd.CreateStartupLimit(ctx, req)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("Created limit with UUID: %s\n", uuid)
+
+// Query all limits
+limits, err := schedd.QueryStartupLimits(ctx, "", "")
+if err != nil {
+    log.Fatal(err)
+}
+for _, limit := range limits {
+    fmt.Printf("%s: %d jobs allowed, %d skipped\n",
+        limit.Name, limit.JobsAllowed, limit.JobsSkipped)
+}
+```
+
+## API Reference
+
+### CreateStartupLimit
+
+Creates or updates a startup rate limit in the schedd.
+
+```go
+func (s *Schedd) CreateStartupLimit(ctx context.Context, req *StartupLimitRequest) (string, error)
+```
+
+**Parameters:**
+- `ctx`: Context (can include security config via `WithSecurityConfig`)
+- `req`: Startup limit parameters
+
+**Returns:**
+- UUID of the created/updated limit
+- Error if the operation fails
+
+**StartupLimitRequest fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `UUID` | string | No | If provided, updates existing limit instead of creating new one |
+| `Tag` | string | **Yes** | Unique identifier for this limit type |
+| `Name` | string | No | Human-friendly display name (defaults to UUID) |
+| `Expression` | string | **Yes** | ClassAd expression to match jobs (e.g., `"RequestGpus > 0"`) |
+| `CostExpression` | string | No | Expression for variable cost (default: `"1"`) |
+| `RateCount` | int | **Yes** | Maximum jobs (or cost units) per window (0 = unlimited monitoring) |
+| `RateWindow` | int | **Yes** | Time window in seconds |
+| `Burst` | int | No | Extra capacity allowed below zero (default: 0) |
+| `MaxBurstCost` | int | No | Cap on single job's cost (default: unlimited) |
+| `Expiration` | int | No | Seconds until limit expires (default: from config) |
+
+### QueryStartupLimits
+
+Queries startup rate limits from the schedd.
+
+```go
+func (s *Schedd) QueryStartupLimits(ctx context.Context, uuid, tag string) ([]*StartupLimit, error)
+```
+
+**Parameters:**
+- `ctx`: Context (can include security config)
+- `uuid`: Filter by UUID (empty = all limits)
+- `tag`: Filter by tag (empty = all limits)
+
+**Returns:**
+- Slice of startup limits matching the query
+- Error if the operation fails
+
+**StartupLimit fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `UUID` | string | Unique identifier |
+| `Tag` | string | Limit type identifier |
+| `Name` | string | Display name |
+| `Expression` | string | Job matching expression |
+| `CostExpression` | string | Variable cost expression |
+| `RateCount` | int | Max rate (jobs or cost units per window) |
+| `RateWindow` | int | Time window in seconds |
+| `Burst` | int | Extra burst capacity |
+| `MaxBurstCost` | int | Cap on single job cost |
+| `ExpiresAt` | int64 | Unix timestamp when limit expires |
+| `JobsAllowed` | int64 | **Stat:** Number of jobs allowed to start |
+| `CostAllowed` | float64 | **Stat:** Total cost allowed |
+| `JobsSkipped` | int64 | **Stat:** Number of jobs skipped (waiting for tokens) |
+| `MatchesIgnored` | int64 | **Stat:** Number of matches ignored (rate limit in effect) |
+| `LastIgnored` | int64 | **Stat:** Unix timestamp of last ignored match |
+| `IgnoredUsers` | string | **Stat:** Comma-separated list of affected users |
+
+## Usage Examples
+
+### Basic Rate Limiting
+
+Limit GPU jobs to 10 per minute:
+
+```go
+req := &htcondor.StartupLimitRequest{
+    Tag:        "gpu_limit",
+    Expression: "RequestGpus > 0",
+    RateCount:  10,
+    RateWindow: 60,
+}
+uuid, err := schedd.CreateStartupLimit(ctx, req)
+```
+
+### Variable Cost
+
+Charge jobs based on CPU count (100 CPU-units per minute):
+
+```go
+req := &htcondor.StartupLimitRequest{
+    Tag:            "cpu_limit",
+    Expression:     "RequestCpus >= 1",
+    CostExpression: "RequestCpus", // 8-core job costs 8 tokens
+    RateCount:      100,
+    RateWindow:     60,
+}
+```
+
+### Burst Capacity
+
+Allow temporary bursts beyond the base rate:
+
+```go
+req := &htcondor.StartupLimitRequest{
+    Tag:        "memory_limit",
+    Expression: "RequestMemory > 16000",
+    RateCount:  5,
+    RateWindow: 60,
+    Burst:      3, // Allow 3 extra jobs even if tokens exhausted
+}
+```
+
+### Monitoring Without Enforcement
+
+Track statistics without limiting job starts:
+
+```go
+req := &htcondor.StartupLimitRequest{
+    Tag:        "monitor_vip",
+    Expression: `Owner == "alice"`,
+    RateCount:  0, // 0 = unlimited, monitoring only
+    RateWindow: 0,
+}
+```
+
+### Capping Individual Jobs
+
+Prevent single large jobs from consuming excessive tokens:
+
+```go
+req := &htcondor.StartupLimitRequest{
+    Tag:            "fair_cpu",
+    Expression:     "RequestCpus >= 1",
+    CostExpression: "RequestCpus",
+    RateCount:      100,
+    RateWindow:     60,
+    MaxBurstCost:   16, // Cap single job at 16 CPUs worth of tokens
+}
+```
+
+### Updating Existing Limits
+
+Specify the UUID to update an existing limit:
+
+```go
+req := &htcondor.StartupLimitRequest{
+    UUID:       "existing-uuid-here",
+    Tag:        "gpu_limit",
+    Expression: "RequestGpus > 0",
+    RateCount:  20, // Increased from 10
+    RateWindow: 60,
+}
+uuid, err := schedd.CreateStartupLimit(ctx, req)
+```
+
+### Querying Statistics
+
+```go
+// Get all limits
+limits, err := schedd.QueryStartupLimits(ctx, "", "")
+
+for _, limit := range limits {
+    if limit.JobsSkipped > 0 {
+        fmt.Printf("%s is actively limiting:\n", limit.Name)
+        fmt.Printf("  Allowed: %d jobs\n", limit.JobsAllowed)
+        fmt.Printf("  Skipped: %d jobs\n", limit.JobsSkipped)
+        fmt.Printf("  Ignored: %d matches\n", limit.MatchesIgnored)
+    }
+}
+```
+
+## How It Works
+
+### Token Bucket Algorithm
+
+Startup limits use a token bucket algorithm:
+
+1. **Tokens** represent permission to start jobs
+2. Tokens **refill** at a constant rate (`RateCount / RateWindow`)
+3. Jobs **consume** tokens when they start (1 token or cost from expression)
+4. If tokens are available, the job starts immediately
+5. If tokens are exhausted, the job waits for the next negotiation cycle
+6. **Burst** allows the bucket to go negative temporarily
+
+### Expression Evaluation
+
+The `Expression` is evaluated against each job's ClassAd to determine if the limit applies:
+
+```
+"RequestGpus > 0"           # Matches jobs requesting any GPUs
+"RequestMemory > 16000"     # Matches high-memory jobs
+"Owner == \"alice\""        # Matches jobs from user alice
+"RequestCpus > 8 && RequestGpus > 0"  # Matches large GPU jobs
+```
+
+The `CostExpression` determines how many tokens each job consumes:
+
+```
+"1"                         # Every job costs 1 token (default)
+"RequestCpus"              # Job costs equal to CPU count
+"RequestGpus * 10"         # GPU jobs cost 10x more
+"RequestMemory / 1000"     # Cost based on memory GB
+```
+
+### Statistics and Monitoring
+
+The schedd tracks statistics for each limit:
+
+- **JobsAllowed**: Jobs successfully started (had tokens)
+- **JobsSkipped**: Jobs delayed (waiting for tokens)
+- **MatchesIgnored**: Total matches that couldn't proceed due to rate limiting
+- **CostAllowed**: Total cost of allowed jobs (if using cost expression)
+- **LastIgnored**: Timestamp of most recent ignored match
+- **IgnoredUsers**: Which users are being affected by the limit
+
+These statistics help you tune rate limits and understand their impact.
+
+## HTCondor Configuration
+
+The schedd supports these configuration parameters:
+
+```
+# Maximum expiration time for limits (default: 300 seconds)
+STARTUP_LIMIT_MAX_EXPIRATION = 3600
+
+# Ban window after ignored match (default: 60 seconds)
+STARTUP_LIMIT_BAN_WINDOW = 60
+
+# Lookahead for throughput throttling (default: 60 seconds)
+STARTUP_LIMIT_LOOKAHEAD = 60
+```
+
+## Best Practices
+
+1. **Start conservative**: Begin with higher rate limits and tighten if needed
+2. **Use monitoring mode first**: Set `RateCount = 0` to observe patterns before enforcing
+3. **Add burst capacity**: Small `Burst` values smooth out job submission spikes
+4. **Cap large jobs**: Use `MaxBurstCost` to prevent single huge jobs from blocking everything
+5. **Set reasonable expirations**: Limits should expire to prevent stale policies
+6. **Monitor statistics**: Regularly check `JobsSkipped` and `MatchesIgnored` to tune limits
+7. **Use meaningful tags**: Tags should indicate the resource or policy being limited
+8. **Document limits**: Use the `Name` field to explain the limit's purpose
+
+## Command Codes
+
+The implementation uses these HTCondor command codes:
+
+- `CREATE_STARTUP_LIMIT` = 559 (`SCHED_VERS + 159`)
+- `QUERY_STARTUP_LIMITS` = 560 (`SCHED_VERS + 160`)
+
+## See Also
+
+- [HTCondor Manual - Job Policy Configuration](https://htcondor.readthedocs.io/)
+- [Examples](examples/startup_limits_demo/)
+- [Tests](schedd_startup_limits_test.go)

--- a/schedd_startup_limits.go
+++ b/schedd_startup_limits.go
@@ -1,0 +1,371 @@
+package htcondor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/bbockelm/cedar/client"
+	"github.com/bbockelm/cedar/message"
+)
+
+// Command codes for startup limits (from condor_commands.h)
+// CREATE_STARTUP_LIMIT = SCHED_VERS + 159 = 400 + 159 = 559
+// QUERY_STARTUP_LIMITS = SCHED_VERS + 160 = 400 + 160 = 560
+const (
+	cmdCreateStartupLimit = 559
+	cmdQueryStartupLimits = 560
+)
+
+// StartupLimit represents a startup rate limit in the schedd
+type StartupLimit struct {
+	UUID           string  `json:"uuid"`
+	Tag            string  `json:"tag"`
+	Name           string  `json:"name,omitempty"`
+	Expression     string  `json:"expression"`
+	CostExpression string  `json:"cost_expression,omitempty"`
+	RateCount      int     `json:"rate_count"`
+	RateWindow     int     `json:"rate_window"` // seconds
+	Burst          int     `json:"burst,omitempty"`
+	MaxBurstCost   int     `json:"max_burst_cost,omitempty"`
+	Expiration     int     `json:"expiration,omitempty"`      // seconds from creation
+	ExpiresAt      int64   `json:"expires_at,omitempty"`      // Unix timestamp
+	JobsAllowed    int64   `json:"jobs_allowed,omitempty"`    // Stats: jobs allowed
+	CostAllowed    float64 `json:"cost_allowed,omitempty"`    // Stats: cost allowed
+	JobsSkipped    int64   `json:"jobs_skipped,omitempty"`    // Stats: jobs skipped
+	MatchesIgnored int64   `json:"matches_ignored,omitempty"` // Stats: matches ignored
+	LastIgnored    int64   `json:"last_ignored,omitempty"`    // Stats: last time match ignored
+	IgnoredUsers   string  `json:"ignored_users,omitempty"`   // Stats: comma-separated list
+}
+
+// StartupLimitRequest represents parameters for creating a startup limit
+type StartupLimitRequest struct {
+	UUID           string `json:"uuid,omitempty"`            // If provided, updates existing limit
+	Tag            string `json:"tag"`                       // Required: unique tag identifier
+	Name           string `json:"name,omitempty"`            // Optional: human-friendly name
+	Expression     string `json:"expression"`                // Required: ClassAd expression to match jobs
+	CostExpression string `json:"cost_expression,omitempty"` // Optional: expression for variable cost (default: 1)
+	RateCount      int    `json:"rate_count"`                // Required: max jobs per window (0 = unlimited monitoring)
+	RateWindow     int    `json:"rate_window"`               // Required: time window in seconds
+	Burst          int    `json:"burst,omitempty"`           // Optional: extra capacity below zero
+	MaxBurstCost   int    `json:"max_burst_cost,omitempty"`  // Optional: cap on single cost
+	Expiration     int    `json:"expiration,omitempty"`      // Optional: expiration in seconds
+}
+
+// StartupLimitResponse represents the response from creating a startup limit
+type StartupLimitResponse struct {
+	Status int    `json:"status"`          // 0 = success, -1 = error
+	UUID   string `json:"uuid,omitempty"`  // UUID of created/updated limit
+	Error  string `json:"error,omitempty"` // Error message if status != 0
+}
+
+// ClassAd attribute names for startup limits
+const (
+	AttrStartupLimitUUID           = "StartupLimitUuid"
+	AttrStartupLimitTag            = "StartupLimitTag"
+	AttrStartupLimitName           = "StartupLimitName"
+	AttrStartupLimitExpr           = "StartupLimitExpr"
+	AttrStartupLimitCostExpr       = "StartupLimitCostExpr"
+	AttrStartupLimitRateCount      = "StartupLimitRateCount"
+	AttrStartupLimitRateWindow     = "StartupLimitRateWindow"
+	AttrStartupLimitBurst          = "StartupLimitBurst"
+	AttrStartupLimitMaxBurstCost   = "StartupLimitMaxBurstCost"
+	AttrStartupLimitExpiration     = "StartupLimitExpiration"
+	AttrStartupLimitStatus         = "StartupLimitStatus"
+	AttrStartupLimitError          = "StartupLimitError"
+	AttrStartupLimitJobsAllowed    = "StartupLimitJobsAllowed"
+	AttrStartupLimitCostAllowed    = "StartupLimitCostAllowed"
+	AttrStartupLimitJobsSkipped    = "StartupLimitJobsSkipped"
+	AttrStartupLimitMatchesIgnored = "StartupLimitMatchesIgnored"
+	AttrStartupLimitLastIgnored    = "StartupLimitLastIgnored"
+	AttrStartupLimitIgnoredUsers   = "StartupLimitIgnoredUsers"
+)
+
+// CreateStartupLimit creates or updates a startup rate limit in the schedd
+//
+// Parameters:
+//   - ctx: Context for the operation (can include security config via WithSecurityConfig)
+//   - req: Startup limit parameters
+//
+// Returns:
+//   - UUID of the created/updated limit
+//   - Error if the operation fails
+//
+// Example:
+//
+//	req := &htcondor.StartupLimitRequest{
+//	    Tag:        "gpu_limit",
+//	    Name:       "GPU Job Rate Limit",
+//	    Expression: "RequestGpus > 0",
+//	    RateCount:  10,
+//	    RateWindow: 60,  // 10 GPU jobs per minute
+//	    Expiration: 3600, // expires in 1 hour
+//	}
+//	uuid, err := schedd.CreateStartupLimit(ctx, req)
+func (s *Schedd) CreateStartupLimit(ctx context.Context, req *StartupLimitRequest) (string, error) {
+	if req == nil {
+		return "", fmt.Errorf("request cannot be nil")
+	}
+	if req.Tag == "" {
+		return "", fmt.Errorf("tag is required")
+	}
+	if req.Expression == "" {
+		return "", fmt.Errorf("expression is required")
+	}
+	if req.RateCount < 0 {
+		return "", fmt.Errorf("rate_count must be non-negative")
+	}
+	if req.RateCount > 0 && req.RateWindow <= 0 {
+		return "", fmt.Errorf("rate_window must be positive when rate_count > 0")
+	}
+
+	// Apply rate limiting if configured
+	username := GetAuthenticatedUserFromContext(ctx)
+	rateLimitManager := getRateLimitManager()
+	if rateLimitManager != nil {
+		if err := rateLimitManager.WaitSchedd(ctx, username); err != nil {
+			return "", fmt.Errorf("rate limit exceeded: %w", err)
+		}
+	}
+
+	// Get SecurityConfig
+	secConfig, err := GetSecurityConfigOrDefault(ctx, nil, cmdCreateStartupLimit, "CLIENT", s.address)
+	if err != nil {
+		return "", fmt.Errorf("failed to create security config: %w", err)
+	}
+
+	// Establish connection and authenticate
+	htcondorClient, err := client.ConnectAndAuthenticate(ctx, s.address, secConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to connect and authenticate to schedd at %s: %w", s.address, err)
+	}
+	defer func() {
+		if cerr := htcondorClient.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("failed to close connection: %w", cerr)
+		}
+	}()
+
+	// Get CEDAR stream from client
+	cedarStream := htcondorClient.GetStream()
+
+	// Build request ClassAd
+	requestAd := classad.New()
+	_ = requestAd.Set(AttrStartupLimitTag, req.Tag)
+
+	// Parse expression as ClassAd expression
+	exprTree, err := classad.ParseExpr(req.Expression)
+	if err != nil {
+		return "", fmt.Errorf("invalid expression: %w", err)
+	}
+	_ = requestAd.Set(AttrStartupLimitExpr, exprTree)
+
+	_ = requestAd.Set(AttrStartupLimitRateCount, int64(req.RateCount))
+	_ = requestAd.Set(AttrStartupLimitRateWindow, int64(req.RateWindow))
+
+	if req.UUID != "" {
+		_ = requestAd.Set(AttrStartupLimitUUID, req.UUID)
+	}
+	if req.Name != "" {
+		_ = requestAd.Set(AttrStartupLimitName, req.Name)
+	}
+	if req.CostExpression != "" {
+		costExpr, err := classad.ParseExpr(req.CostExpression)
+		if err != nil {
+			return "", fmt.Errorf("invalid cost expression: %w", err)
+		}
+		_ = requestAd.Set(AttrStartupLimitCostExpr, costExpr)
+	}
+	if req.Burst > 0 {
+		_ = requestAd.Set(AttrStartupLimitBurst, int64(req.Burst))
+	}
+	if req.MaxBurstCost > 0 {
+		_ = requestAd.Set(AttrStartupLimitMaxBurstCost, int64(req.MaxBurstCost))
+	}
+	if req.Expiration > 0 {
+		_ = requestAd.Set(AttrStartupLimitExpiration, int64(req.Expiration))
+	}
+
+	// Send request ClassAd
+	msg := message.NewMessageForStream(cedarStream)
+	if err := msg.PutClassAd(ctx, requestAd); err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	if err := msg.FinishMessage(ctx); err != nil {
+		return "", fmt.Errorf("failed to send end of message: %w", err)
+	}
+
+	// Receive response
+	responseMsg := message.NewMessageFromStream(cedarStream)
+	replyAd, err := responseMsg.GetClassAd(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to receive response: %w", err)
+	}
+
+	// Parse response
+	status, ok := replyAd.EvaluateAttrInt(AttrStartupLimitStatus)
+	if !ok {
+		return "", fmt.Errorf("response missing status")
+	}
+
+	if status != 0 {
+		errMsg := "unknown error"
+		if val, ok := replyAd.EvaluateAttrString(AttrStartupLimitError); ok {
+			errMsg = val
+		}
+		return "", fmt.Errorf("schedd rejected request: %s", errMsg)
+	}
+
+	uuid, ok := replyAd.EvaluateAttrString(AttrStartupLimitUUID)
+	if !ok {
+		return "", fmt.Errorf("response missing uuid")
+	}
+
+	return uuid, nil
+}
+
+// QueryStartupLimits queries startup rate limits from the schedd
+//
+// Parameters:
+//   - ctx: Context for the operation (can include security config via WithSecurityConfig)
+//   - uuid: Optional UUID to filter results (empty string = all limits)
+//   - tag: Optional tag to filter results (empty string = all limits)
+//
+// Returns:
+//   - Slice of startup limits matching the query
+//   - Error if the operation fails
+//
+// Example:
+//
+//	// Get all limits
+//	limits, err := schedd.QueryStartupLimits(ctx, "", "")
+//
+//	// Get specific limit by UUID
+//	limits, err := schedd.QueryStartupLimits(ctx, "abc123", "")
+//
+//	// Get all limits with tag
+//	limits, err := schedd.QueryStartupLimits(ctx, "", "gpu_limit")
+func (s *Schedd) QueryStartupLimits(ctx context.Context, uuid, tag string) ([]*StartupLimit, error) {
+	// Apply rate limiting if configured
+	username := GetAuthenticatedUserFromContext(ctx)
+	rateLimitManager := getRateLimitManager()
+	if rateLimitManager != nil {
+		if err := rateLimitManager.WaitSchedd(ctx, username); err != nil {
+			return nil, fmt.Errorf("rate limit exceeded: %w", err)
+		}
+	}
+
+	// Get SecurityConfig
+	secConfig, err := GetSecurityConfigOrDefault(ctx, nil, cmdQueryStartupLimits, "CLIENT", s.address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create security config: %w", err)
+	}
+
+	// Establish connection and authenticate
+	htcondorClient, err := client.ConnectAndAuthenticate(ctx, s.address, secConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect and authenticate to schedd at %s: %w", s.address, err)
+	}
+	defer func() {
+		if cerr := htcondorClient.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("failed to close connection: %w", cerr)
+		}
+	}()
+
+	// Get CEDAR stream from client
+	cedarStream := htcondorClient.GetStream()
+
+	// Build request ClassAd with filters
+	requestAd := classad.New()
+	if uuid != "" {
+		_ = requestAd.Set(AttrStartupLimitUUID, uuid)
+	}
+	if tag != "" {
+		_ = requestAd.Set(AttrStartupLimitTag, tag)
+	}
+
+	// Send request ClassAd
+	msg := message.NewMessageForStream(cedarStream)
+	if err := msg.PutClassAd(ctx, requestAd); err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	if err := msg.FinishMessage(ctx); err != nil {
+		return nil, fmt.Errorf("failed to send end of message: %w", err)
+	}
+
+	// Receive response ads
+	var limits []*StartupLimit
+	for {
+		responseMsg := message.NewMessageFromStream(cedarStream)
+		ad, err := responseMsg.GetClassAd(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to receive response: %w", err)
+		}
+
+		// Check for "Last" marker indicating end of results
+		if val, ok := ad.EvaluateAttrBool("Last"); ok && val {
+			break
+		}
+
+		// Parse startup limit from ClassAd
+		limit := parseStartupLimitAd(ad)
+		limits = append(limits, limit)
+	}
+
+	return limits, nil
+}
+
+// parseStartupLimitAd converts a ClassAd to a StartupLimit struct
+func parseStartupLimitAd(ad *classad.ClassAd) *StartupLimit {
+	limit := &StartupLimit{}
+
+	if val, ok := ad.EvaluateAttrString(AttrStartupLimitUUID); ok {
+		limit.UUID = val
+	}
+	if val, ok := ad.EvaluateAttrString(AttrStartupLimitTag); ok {
+		limit.Tag = val
+	}
+	if val, ok := ad.EvaluateAttrString(AttrStartupLimitName); ok {
+		limit.Name = val
+	}
+	if val, ok := ad.EvaluateAttrString(AttrStartupLimitExpr); ok {
+		limit.Expression = val
+	}
+	if val, ok := ad.EvaluateAttrString(AttrStartupLimitCostExpr); ok {
+		limit.CostExpression = val
+	}
+	if val, ok := ad.EvaluateAttrInt(AttrStartupLimitRateCount); ok {
+		limit.RateCount = int(val)
+	}
+	if val, ok := ad.EvaluateAttrInt(AttrStartupLimitRateWindow); ok {
+		limit.RateWindow = int(val)
+	}
+	if val, ok := ad.EvaluateAttrInt(AttrStartupLimitBurst); ok {
+		limit.Burst = int(val)
+	}
+	if val, ok := ad.EvaluateAttrInt(AttrStartupLimitMaxBurstCost); ok {
+		limit.MaxBurstCost = int(val)
+	}
+	if val, ok := ad.EvaluateAttrInt(AttrStartupLimitExpiration); ok {
+		limit.ExpiresAt = val
+	}
+	if val, ok := ad.EvaluateAttrInt(AttrStartupLimitJobsAllowed); ok {
+		limit.JobsAllowed = val
+	}
+	if val, ok := ad.EvaluateAttrReal(AttrStartupLimitCostAllowed); ok {
+		limit.CostAllowed = val
+	}
+	if val, ok := ad.EvaluateAttrInt(AttrStartupLimitJobsSkipped); ok {
+		limit.JobsSkipped = val
+	}
+	if val, ok := ad.EvaluateAttrInt(AttrStartupLimitMatchesIgnored); ok {
+		limit.MatchesIgnored = val
+	}
+	if val, ok := ad.EvaluateAttrInt(AttrStartupLimitLastIgnored); ok {
+		limit.LastIgnored = val
+	}
+	if val, ok := ad.EvaluateAttrString(AttrStartupLimitIgnoredUsers); ok {
+		limit.IgnoredUsers = val
+	}
+
+	return limit
+}

--- a/schedd_startup_limits_integration_test.go
+++ b/schedd_startup_limits_integration_test.go
@@ -1,0 +1,371 @@
+package htcondor
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestScheddStartupLimitsIntegration tests the startup limits functionality
+//
+// Note: This test requires HTCondor v25.6.0 or later with startup limits support.
+// If the schedd doesn't support startup limits commands (559/560), the test will
+// skip gracefully after verifying that validation and error handling work correctly.
+//
+//nolint:gocyclo // Integration test with multiple subtests is acceptable
+func TestScheddStartupLimitsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Check if condor_master is available
+	if _, err := exec.LookPath("condor_master"); err != nil {
+		t.Skip("condor_master not found in PATH - skipping integration test")
+	}
+
+	// Set up mini HTCondor environment
+	harness := SetupCondorHarness(t)
+
+	// Wait for daemons to start
+	if err := harness.WaitForDaemons(); err != nil {
+		t.Fatalf("Daemons failed to start: %v", err)
+	}
+
+	collectorAddr := harness.GetCollectorAddr()
+
+	// Locate schedd using collector
+	collector := NewCollector(collectorAddr)
+	locateCtx, locateCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer locateCancel()
+
+	location, err := collector.LocateDaemon(locateCtx, "Schedd", "")
+	if err != nil {
+		t.Fatalf("Failed to locate schedd: %v", err)
+	}
+
+	t.Logf("Found schedd: %s at %s", location.Name, location.Address)
+
+	// Create Schedd instance
+	schedd := NewSchedd(location.Name, location.Address)
+
+	// Track if server supports startup limits
+	serverSupportsStartupLimits := true
+
+	t.Run("CreateBasicStartupLimit", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Create a basic startup limit
+		request := &StartupLimitRequest{
+			Tag:        "test_basic_limit",
+			Name:       "Test Basic Limit",
+			Expression: "Owner == \"testuser\"",
+			RateCount:  10,
+			RateWindow: 60,
+		}
+
+		uuid, err := schedd.CreateStartupLimit(ctx, request)
+		if err != nil {
+			// Check if server doesn't support startup limits
+			if strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "authentication handshake failed") {
+				serverSupportsStartupLimits = false
+				t.Skipf("Schedd does not support startup limits (requires HTCondor v25.6.0+): %v", err)
+			}
+			t.Fatalf("Failed to create startup limit: %v", err)
+		}
+
+		t.Logf("Created startup limit: UUID=%s", uuid)
+
+		// Verify UUID was returned
+		if uuid == "" {
+			t.Error("Expected UUID to be set")
+		}
+
+		// Query to verify the limit was created with correct attributes
+		limits, err := schedd.QueryStartupLimits(ctx, uuid, "")
+		if err != nil {
+			t.Fatalf("Failed to query created limit: %v", err)
+		}
+
+		if len(limits) != 1 {
+			t.Fatalf("Expected exactly 1 limit with UUID=%s, got %d", uuid, len(limits))
+		}
+
+		limit := limits[0]
+		if limit.Tag != "test_basic_limit" {
+			t.Errorf("Expected Tag='test_basic_limit', got '%s'", limit.Tag)
+		}
+		if limit.Name != "Test Basic Limit" {
+			t.Errorf("Expected Name='Test Basic Limit', got '%s'", limit.Name)
+		}
+		if limit.Expression != "Owner == \"testuser\"" {
+			t.Errorf("Expected Expression='Owner == \"testuser\"', got '%s'", limit.Expression)
+		}
+		if limit.RateCount != 10 {
+			t.Errorf("Expected RateCount=10, got %d", limit.RateCount)
+		}
+		if limit.RateWindow != 60 {
+			t.Errorf("Expected RateWindow=60, got %d", limit.RateWindow)
+		}
+	})
+
+	t.Run("CreateLimitWithCostExpression", func(t *testing.T) {
+		if !serverSupportsStartupLimits {
+			t.Skip("Schedd does not support startup limits")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Create a limit with cost expression
+		request := &StartupLimitRequest{
+			Tag:            "test_cost_limit",
+			Name:           "Test Cost Limit",
+			Expression:     "JobUniverse == 5",
+			CostExpression: "RequestCpus",
+			RateCount:      100,
+			RateWindow:     60,
+			Burst:          20,
+		}
+
+		uuid, err := schedd.CreateStartupLimit(ctx, request)
+		if err != nil {
+			t.Fatalf("Failed to create startup limit with cost expression: %v", err)
+		}
+
+		t.Logf("Created cost-based limit: UUID=%s", uuid)
+
+		// Query to verify attributes
+		limits, err := schedd.QueryStartupLimits(ctx, uuid, "")
+		if err != nil {
+			t.Fatalf("Failed to query created limit: %v", err)
+		}
+
+		if len(limits) != 1 {
+			t.Fatalf("Expected exactly 1 limit, got %d", len(limits))
+		}
+
+		limit := limits[0]
+		if limit.CostExpression != "RequestCpus" {
+			t.Errorf("Expected CostExpression='RequestCpus', got '%s'", limit.CostExpression)
+		}
+		if limit.Burst != 20 {
+			t.Errorf("Expected Burst=20, got %d", limit.Burst)
+		}
+	})
+
+	t.Run("QueryAllStartupLimits", func(t *testing.T) {
+		if !serverSupportsStartupLimits {
+			t.Skip("Schedd does not support startup limits")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Query all startup limits
+		limits, err := schedd.QueryStartupLimits(ctx, "", "")
+		if err != nil {
+			t.Fatalf("Failed to query startup limits: %v", err)
+		}
+
+		t.Logf("Found %d startup limit(s)", len(limits))
+
+		// Should have at least the two we just created
+		if len(limits) < 2 {
+			t.Errorf("Expected at least 2 limits, got %d", len(limits))
+		}
+
+		// Verify we can find our test limits
+		foundBasic := false
+		foundCost := false
+		for _, limit := range limits {
+			t.Logf("Limit: UUID=%s, Tag=%s, Name=%s, RateCount=%d, RateWindow=%d",
+				limit.UUID, limit.Tag, limit.Name, limit.RateCount, limit.RateWindow)
+
+			if limit.Tag == "test_basic_limit" {
+				foundBasic = true
+			}
+			if limit.Tag == "test_cost_limit" {
+				foundCost = true
+			}
+		}
+
+		if !foundBasic {
+			t.Error("Did not find 'test_basic_limit' in query results")
+		}
+		if !foundCost {
+			t.Error("Did not find 'test_cost_limit' in query results")
+		}
+	})
+
+	t.Run("QueryStartupLimitByTag", func(t *testing.T) {
+		if !serverSupportsStartupLimits {
+			t.Skip("Schedd does not support startup limits")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Query by specific tag
+		limits, err := schedd.QueryStartupLimits(ctx, "", "test_basic_limit")
+		if err != nil {
+			t.Fatalf("Failed to query startup limits by tag: %v", err)
+		}
+
+		if len(limits) != 1 {
+			t.Fatalf("Expected exactly 1 limit with tag 'test_basic_limit', got %d", len(limits))
+		}
+
+		limit := limits[0]
+		if limit.Tag != "test_basic_limit" {
+			t.Errorf("Expected Tag='test_basic_limit', got '%s'", limit.Tag)
+		}
+
+		t.Logf("Found limit by tag: UUID=%s, Name=%s", limit.UUID, limit.Name)
+	})
+
+	t.Run("UpdateExistingLimit", func(t *testing.T) {
+		if !serverSupportsStartupLimits {
+			t.Skip("Schedd does not support startup limits")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// First query to get the UUID
+		limits, err := schedd.QueryStartupLimits(ctx, "", "test_basic_limit")
+		if err != nil {
+			t.Fatalf("Failed to query for existing limit: %v", err)
+		}
+		if len(limits) == 0 {
+			t.Fatal("Expected to find 'test_basic_limit' for update test")
+		}
+
+		existingLimit := limits[0]
+		t.Logf("Updating limit with UUID=%s", existingLimit.UUID)
+
+		// Update the limit with new rate
+		request := &StartupLimitRequest{
+			UUID:       existingLimit.UUID,
+			Tag:        "test_basic_limit",
+			Name:       "Test Basic Limit - Updated",
+			Expression: "Owner == \"testuser\"",
+			RateCount:  20, // Changed from 10
+			RateWindow: 60,
+		}
+
+		updatedUUID, err := schedd.CreateStartupLimit(ctx, request)
+		if err != nil {
+			t.Fatalf("Failed to update startup limit: %v", err)
+		}
+
+		t.Logf("Updated limit: UUID=%s", updatedUUID)
+
+		// Verify update - UUID should stay the same
+		if updatedUUID != existingLimit.UUID {
+			t.Errorf("UUID changed during update: %s -> %s", existingLimit.UUID, updatedUUID)
+		}
+
+		// Query updated limit to verify changes
+		updatedLimits, err := schedd.QueryStartupLimits(ctx, updatedUUID, "")
+		if err != nil {
+			t.Fatalf("Failed to query updated limit: %v", err)
+		}
+
+		if len(updatedLimits) != 1 {
+			t.Fatalf("Expected exactly 1 updated limit, got %d", len(updatedLimits))
+		}
+
+		updatedLimit := updatedLimits[0]
+		if updatedLimit.Name != "Test Basic Limit - Updated" {
+			t.Errorf("Name not updated: got '%s'", updatedLimit.Name)
+		}
+		if updatedLimit.RateCount != 20 {
+			t.Errorf("RateCount not updated: expected 20, got %d", updatedLimit.RateCount)
+		}
+	})
+
+	t.Run("CreateLimitWithExpiration", func(t *testing.T) {
+		if !serverSupportsStartupLimits {
+			t.Skip("Schedd does not support startup limits")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Create a limit with expiration
+		request := &StartupLimitRequest{
+			Tag:        "test_expiring_limit",
+			Name:       "Test Expiring Limit",
+			Expression: "true",
+			RateCount:  5,
+			RateWindow: 60,
+			Expiration: 3600, // 1 hour
+		}
+
+		uuid, err := schedd.CreateStartupLimit(ctx, request)
+		if err != nil {
+			t.Fatalf("Failed to create startup limit with expiration: %v", err)
+		}
+
+		t.Logf("Created expiring limit: UUID=%s", uuid)
+
+		// Query to verify expiration attributes
+		limits, err := schedd.QueryStartupLimits(ctx, uuid, "")
+		if err != nil {
+			t.Fatalf("Failed to query created limit: %v", err)
+		}
+
+		if len(limits) != 1 {
+			t.Fatalf("Expected exactly 1 limit, got %d", len(limits))
+		}
+
+		limit := limits[0]
+		if limit.Expiration != 3600 {
+			t.Errorf("Expected Expiration=3600, got %d", limit.Expiration)
+		}
+		if limit.ExpiresAt == 0 {
+			t.Error("Expected ExpiresAt to be set (non-zero)")
+		}
+	})
+
+	t.Run("InvalidRequests", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		tests := []struct {
+			name    string
+			request *StartupLimitRequest
+		}{
+			{
+				name:    "MissingTag",
+				request: &StartupLimitRequest{Expression: "true", RateCount: 10, RateWindow: 60},
+			},
+			{
+				name:    "MissingExpression",
+				request: &StartupLimitRequest{Tag: "test", RateCount: 10, RateWindow: 60},
+			},
+			{
+				name:    "NegativeRateCount",
+				request: &StartupLimitRequest{Tag: "test", Expression: "true", RateCount: -1, RateWindow: 60},
+			},
+			{
+				name:    "ZeroRateWindow",
+				request: &StartupLimitRequest{Tag: "test", Expression: "true", RateCount: 10, RateWindow: 0},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := schedd.CreateStartupLimit(ctx, tt.request)
+				if err == nil {
+					t.Error("Expected error for invalid request, but got none")
+				} else {
+					t.Logf("Got expected error: %v", err)
+				}
+			})
+		}
+	})
+}

--- a/schedd_startup_limits_test.go
+++ b/schedd_startup_limits_test.go
@@ -1,0 +1,177 @@
+package htcondor
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStartupLimitRequest_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *StartupLimitRequest
+		wantErr bool
+	}{
+		{
+			name: "valid basic limit",
+			req: &StartupLimitRequest{
+				Tag:        "test_limit",
+				Expression: "RequestGpus > 0",
+				RateCount:  10,
+				RateWindow: 60,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "nil request",
+			req:     nil,
+			wantErr: true,
+		},
+		{
+			name: "missing tag",
+			req: &StartupLimitRequest{
+				Expression: "RequestGpus > 0",
+				RateCount:  10,
+				RateWindow: 60,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing expression",
+			req: &StartupLimitRequest{
+				Tag:        "test_limit",
+				RateCount:  10,
+				RateWindow: 60,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative rate count",
+			req: &StartupLimitRequest{
+				Tag:        "test_limit",
+				Expression: "RequestGpus > 0",
+				RateCount:  -1,
+				RateWindow: 60,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero rate window with positive count",
+			req: &StartupLimitRequest{
+				Tag:        "test_limit",
+				Expression: "RequestGpus > 0",
+				RateCount:  10,
+				RateWindow: 0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero rate count (unlimited monitoring)",
+			req: &StartupLimitRequest{
+				Tag:        "test_limit",
+				Expression: "RequestGpus > 0",
+				RateCount:  0,
+				RateWindow: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "with optional fields",
+			req: &StartupLimitRequest{
+				Tag:            "test_limit",
+				Name:           "GPU Rate Limit",
+				Expression:     "RequestGpus > 0",
+				CostExpression: "RequestGpus",
+				RateCount:      10,
+				RateWindow:     60,
+				Burst:          5,
+				MaxBurstCost:   3,
+				Expiration:     3600,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake schedd (we won't actually connect)
+			schedd := &Schedd{
+				name:    "test_schedd",
+				address: "localhost:9618",
+			}
+
+			// We can't actually test CreateStartupLimit without a real schedd,
+			// but we can test the validation logic by examining the inputs
+			var err error
+			if tt.req == nil {
+				_, err = schedd.CreateStartupLimit(context.TODO(), tt.req)
+			} else {
+				// Validate the same checks that CreateStartupLimit performs
+				switch {
+				case tt.req.Tag == "":
+					err = &validationError{msg: "tag is required"}
+				case tt.req.Expression == "":
+					err = &validationError{msg: "expression is required"}
+				case tt.req.RateCount < 0:
+					err = &validationError{msg: "rate_count must be non-negative"}
+				case tt.req.RateCount > 0 && tt.req.RateWindow <= 0:
+					err = &validationError{msg: "rate_window must be positive when rate_count > 0"}
+				}
+			}
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validation error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// validationError is a helper type for testing validation
+type validationError struct {
+	msg string
+}
+
+func (e *validationError) Error() string {
+	return e.msg
+}
+
+func TestStartupLimitConstants(t *testing.T) {
+	// Verify command codes match HTCondor's condor_commands.h
+	// CREATE_STARTUP_LIMIT = SCHED_VERS + 159 = 400 + 159 = 559
+	// QUERY_STARTUP_LIMITS = SCHED_VERS + 160 = 400 + 160 = 560
+	if cmdCreateStartupLimit != 559 {
+		t.Errorf("cmdCreateStartupLimit = %d, want 559", cmdCreateStartupLimit)
+	}
+	if cmdQueryStartupLimits != 560 {
+		t.Errorf("cmdQueryStartupLimits = %d, want 560", cmdQueryStartupLimits)
+	}
+}
+
+func TestStartupLimitAttributeNames(t *testing.T) {
+	// Verify attribute names match HTCondor's expectations
+	expectedAttrs := map[string]string{
+		"StartupLimitUuid":           AttrStartupLimitUUID,
+		"StartupLimitTag":            AttrStartupLimitTag,
+		"StartupLimitName":           AttrStartupLimitName,
+		"StartupLimitExpr":           AttrStartupLimitExpr,
+		"StartupLimitCostExpr":       AttrStartupLimitCostExpr,
+		"StartupLimitRateCount":      AttrStartupLimitRateCount,
+		"StartupLimitRateWindow":     AttrStartupLimitRateWindow,
+		"StartupLimitBurst":          AttrStartupLimitBurst,
+		"StartupLimitMaxBurstCost":   AttrStartupLimitMaxBurstCost,
+		"StartupLimitExpiration":     AttrStartupLimitExpiration,
+		"StartupLimitStatus":         AttrStartupLimitStatus,
+		"StartupLimitError":          AttrStartupLimitError,
+		"StartupLimitJobsAllowed":    AttrStartupLimitJobsAllowed,
+		"StartupLimitCostAllowed":    AttrStartupLimitCostAllowed,
+		"StartupLimitJobsSkipped":    AttrStartupLimitJobsSkipped,
+		"StartupLimitMatchesIgnored": AttrStartupLimitMatchesIgnored,
+		"StartupLimitLastIgnored":    AttrStartupLimitLastIgnored,
+		"StartupLimitIgnoredUsers":   AttrStartupLimitIgnoredUsers,
+	}
+
+	for expected, actual := range expectedAttrs {
+		if expected != actual {
+			t.Errorf("attribute name mismatch: expected %q, got %q", expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
This exposes the new startup limit feature, allowing an external agent to rate-limit the jobs.