### PR TITLE
Improve error messages and fosite token detection

### DIFF
--- a/cmd/htcondor-api/token_fetch.go
+++ b/cmd/htcondor-api/token_fetch.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	"github.com/bbockelm/golang-htcondor/config"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // TokenInfo stores OAuth2 token information for a trust domain
@@ -636,43 +636,26 @@ func checkExistingToken(trustDomain string) (string, error) {
 
 // isValidTokenForDomain checks if a token is valid JWT for the specific trust domain and won't expire for at least 5 minutes
 func isValidTokenForDomain(token, trustDomain string) bool {
-	// Parse JWT to check expiration and issuer
-	// JWT format: header.payload.signature
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
+	// Parse the JWT without verifying its signature — we only need the
+	// issuer and expiry claims to decide whether this cached token is
+	// still usable. Signature verification happens later at the schedd.
+	var claims jwt.RegisteredClaims
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
 		return false
 	}
 
-	// Decode payload (base64url)
-	payloadData, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		// Try with standard base64
-		payloadData, err = base64.RawStdEncoding.DecodeString(parts[1])
-		if err != nil {
-			return false
-		}
-	}
-
-	// Parse JSON payload
-	var payload struct {
-		Exp int64  `json:"exp"`
-		Iss string `json:"iss"`
-	}
-	if err := json.Unmarshal(payloadData, &payload); err != nil {
+	// Check if token's issuer matches the trust domain.
+	// The issuer URL should contain the trust domain as its host.
+	if !strings.Contains(claims.Issuer, trustDomain) {
 		return false
 	}
 
-	// Check if token's issuer matches the trust domain
-	// The issuer URL should contain the trust domain as its host
-	if !strings.Contains(payload.Iss, trustDomain) {
+	// Check if token expires in more than 5 minutes.
+	if claims.ExpiresAt == nil {
 		return false
 	}
-
-	// Check if token expires in more than 5 minutes
-	expiresAt := time.Unix(payload.Exp, 0)
-	fiveMinutesFromNow := time.Now().Add(5 * time.Minute)
-
-	return expiresAt.After(fiveMinutesFromNow)
+	return claims.ExpiresAt.After(time.Now().Add(5 * time.Minute))
 }
 
 // getTokenDirectory returns the token directory path from SEC_TOKEN_DIRECTORY or ~/.condor/tokens.d

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -8,7 +8,7 @@ require github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 
 require (
 	github.com/PelicanPlatform/classad v0.0.4 // indirect
-	github.com/bbockelm/cedar v0.0.25 // indirect
+	github.com/bbockelm/cedar v0.0.26 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/crypto v0.50.0 // indirect

--- a/examples/basic/go.sum
+++ b/examples/basic/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.0.4 h1:CKRLqSe+6tTvYELE/P1uYYugse8aAMKAnb+IC5HDqIU=
 github.com/PelicanPlatform/classad v0.0.4/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.0.25 h1:XvouwA5rICXLHAXTjSeuu1UxR5/aadKsjpXGljWSf/4=
-github.com/bbockelm/cedar v0.0.25/go.mod h1:K3g+fJeOUKWIZyOcFC29dAisP7oYH+IqCuLQQLW5n1U=
+github.com/bbockelm/cedar v0.0.26 h1:3pJtBHaTrIKesF6sYpftP9ioBOsFz4+Ok95QXF9IfEw=
+github.com/bbockelm/cedar v0.0.26/go.mod h1:K3g+fJeOUKWIZyOcFC29dAisP7oYH+IqCuLQQLW5n1U=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/examples/file_transfer_demo/go.mod
+++ b/examples/file_transfer_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/bbockelm/golang-htcondor => ../..
 
 require (
 	github.com/PelicanPlatform/classad v0.0.4
-	github.com/bbockelm/cedar v0.0.25
+	github.com/bbockelm/cedar v0.0.26
 	github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/file_transfer_demo/go.sum
+++ b/examples/file_transfer_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.0.4 h1:CKRLqSe+6tTvYELE/P1uYYugse8aAMKAnb+IC5HDqIU=
 github.com/PelicanPlatform/classad v0.0.4/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.0.25 h1:XvouwA5rICXLHAXTjSeuu1UxR5/aadKsjpXGljWSf/4=
-github.com/bbockelm/cedar v0.0.25/go.mod h1:K3g+fJeOUKWIZyOcFC29dAisP7oYH+IqCuLQQLW5n1U=
+github.com/bbockelm/cedar v0.0.26 h1:3pJtBHaTrIKesF6sYpftP9ioBOsFz4+Ok95QXF9IfEw=
+github.com/bbockelm/cedar v0.0.26/go.mod h1:K3g+fJeOUKWIZyOcFC29dAisP7oYH+IqCuLQQLW5n1U=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/examples/queue_demo/go.mod
+++ b/examples/queue_demo/go.mod
@@ -13,7 +13,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad v0.0.4 // indirect
-	github.com/bbockelm/cedar v0.0.25 // indirect
+	github.com/bbockelm/cedar v0.0.26 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/examples/queue_demo/go.sum
+++ b/examples/queue_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.0.4 h1:CKRLqSe+6tTvYELE/P1uYYugse8aAMKAnb+IC5HDqIU=
 github.com/PelicanPlatform/classad v0.0.4/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.0.25 h1:XvouwA5rICXLHAXTjSeuu1UxR5/aadKsjpXGljWSf/4=
-github.com/bbockelm/cedar v0.0.25/go.mod h1:K3g+fJeOUKWIZyOcFC29dAisP7oYH+IqCuLQQLW5n1U=
+github.com/bbockelm/cedar v0.0.26 h1:3pJtBHaTrIKesF6sYpftP9ioBOsFz4+Ok95QXF9IfEw=
+github.com/bbockelm/cedar v0.0.26/go.mod h1:K3g+fJeOUKWIZyOcFC29dAisP7oYH+IqCuLQQLW5n1U=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.0.4
-	github.com/bbockelm/cedar v0.0.25
+	github.com/bbockelm/cedar v0.0.26
 	github.com/bbockelm/gosssd v0.0.1
 	github.com/glebarez/sqlite v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/bbockelm/cedar v0.0.25 h1:XvouwA5rICXLHAXTjSeuu1UxR5/aadKsjpXGljWSf/4=
-github.com/bbockelm/cedar v0.0.25/go.mod h1:K3g+fJeOUKWIZyOcFC29dAisP7oYH+IqCuLQQLW5n1U=
+github.com/bbockelm/cedar v0.0.26 h1:3pJtBHaTrIKesF6sYpftP9ioBOsFz4+Ok95QXF9IfEw=
+github.com/bbockelm/cedar v0.0.26/go.mod h1:K3g+fJeOUKWIZyOcFC29dAisP7oYH+IqCuLQQLW5n1U=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/httpserver/mcp_handlers.go
+++ b/httpserver/mcp_handlers.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bbockelm/cedar/security"
 	htcondor "github.com/bbockelm/golang-htcondor"
 	"github.com/bbockelm/golang-htcondor/logging"
 	"github.com/bbockelm/golang-htcondor/mcpserver"
@@ -327,34 +326,47 @@ func (h *Handler) validateOAuth2Token(r *http.Request) (fosite.AccessRequester, 
 }
 
 // tokenInspection is the diagnostic payload we log when a token
-// fails OAuth2 introspection. All fields may be empty: a token that
-// doesn't parse as a JWT yields a zero-value tokenInspection, and
-// individual claims may be absent. The values are NEVER trusted for
-// authorization decisions; they exist solely so a server log can
-// answer "what did the token actually look like?" without the
-// operator having to capture and decode the Bearer header.
+// fails OAuth2 introspection AND the input to the classifier's
+// origin decision. All fields may be empty: a token that doesn't
+// parse as a JWT yields a zero-value tokenInspection, and
+// individual claims may be absent. The values are NEVER trusted
+// for AUTHORIZATION decisions (those go through the schedd's
+// signature verifier); the marker is only used for routing the
+// HTTP response — 401-to-our-client vs. forward-to-schedd.
 type tokenInspection struct {
-	Issuer  string
-	Subject string
-	KeyID   string // header.kid; identifies the signing key in passwords.d/
+	Issuer   string
+	Subject  string
+	KeyID    string // header.kid; identifies the signing key in passwords.d/
+	TokenUse string // "mcp-oauth2" on tokens this server's OAuth2 flow minted; "" on real condor IDTOKENs
 }
 
 // inspectToken extracts the diagnostic-useful claims from a JWT
 // without verifying the signature. Used by the auth failure log
-// path; production routing decisions go through classifyUnknownToken
-// which calls into this same parser. Failing to parse returns the
-// zero value — the caller's log will then show empty fields, which
-// is itself a useful signal (the Bearer wasn't even a JWT).
+// path AND by classifyUnknownToken's origin decision. Failing to
+// parse returns the zero value — the caller's log will then show
+// empty fields, which is itself a useful signal (the Bearer wasn't
+// even a JWT).
+//
+// We parse with jwt.MapClaims so non-RFC-7519 claims like
+// `token_use` (our sentinel) are reachable. RegisteredClaims would
+// drop them silently.
 func inspectToken(tokenString string) tokenInspection {
 	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
-	parsed, _, err := parser.ParseUnverified(tokenString, &jwt.RegisteredClaims{})
+	parsed, _, err := parser.ParseUnverified(tokenString, jwt.MapClaims{})
 	if err != nil {
 		return tokenInspection{}
 	}
 	out := tokenInspection{}
-	if claims, ok := parsed.Claims.(*jwt.RegisteredClaims); ok {
-		out.Issuer = claims.Issuer
-		out.Subject = claims.Subject
+	if claims, ok := parsed.Claims.(jwt.MapClaims); ok {
+		if v, ok := claims["iss"].(string); ok {
+			out.Issuer = v
+		}
+		if v, ok := claims["sub"].(string); ok {
+			out.Subject = v
+		}
+		if v, ok := claims["token_use"].(string); ok {
+			out.TokenUse = v
+		}
 	}
 	// Header is a map[string]any; kid may be absent or non-string on
 	// malformed tokens — return "" silently in either case.
@@ -376,37 +388,54 @@ const (
 	tokenClassUnparseable   tokenClass = "unparseable"    // not a JWT at all; 401
 )
 
-// classifyUnknownToken inspects the `iss` claim of a token fosite
-// just rejected to decide whether it could legitimately be a
-// HTCondor IDTOKEN or whether it's something we should 401 on. The
-// parse is unverified — we're not checking the signature, just
-// reading the issuer — because actual signature verification is
-// what fosite + the schedd are doing further along.
+// classifyUnknownToken decides whether a token fosite just rejected
+// should be forwarded to the schedd (real condor_token_create
+// output) or surfaced as a 401 (one of our own OAuth2 tokens that
+// expired / got revoked / was minted against a rotated key).
+//
+// PRIMARY signal: the `token_use` claim. Our OAuth2 mint stamps
+// every access token with `token_use = MCPTokenUseMarker`; real
+// HTCondor IDTOKENs never carry this field. When present, the
+// token is positively identified as ours regardless of issuer —
+// which is what lets us distinguish in deployments where the
+// OAuth2 issuer is configured to equal TRUST_DOMAIN (both kinds
+// of token then have identical iss/sub/kid).
+//
+// FALLBACK signal: the `iss` claim, for tokens minted before the
+// marker was introduced and for genuinely-foreign tokens. If iss
+// matches the configured OAuth2 issuer we 401; if it matches
+// TRUST_DOMAIN we forward; otherwise we 401.
+//
+// The classifier never verifies the signature — fosite (already
+// failed) and the schedd (where forwarded tokens go) handle that.
+// Forging a `token_use` claim is therefore possible at this layer,
+// but the worst-case is "attacker's unsigned token gets 401'd
+// instead of also-401'd at the schedd"; no privilege escalation.
 func (h *Handler) classifyUnknownToken(tokenString string) tokenClass {
-	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
-	parsed, _, perr := parser.ParseUnverified(tokenString, &jwt.RegisteredClaims{})
-	if perr != nil {
+	insp := inspectToken(tokenString)
+	if insp.Issuer == "" && insp.Subject == "" && insp.TokenUse == "" && insp.KeyID == "" {
+		// inspectToken returns zero value when the input isn't a
+		// parseable JWT at all. Treat as unparseable.
 		return tokenClassUnparseable
 	}
-	claims, ok := parsed.Claims.(*jwt.RegisteredClaims)
-	if !ok || claims.Issuer == "" {
-		return tokenClassUnknownIssuer
-	}
-	// Our IDP-issued tokens carry the configured AccessTokenIssuer.
-	// Reject anything bearing that issuer that fosite couldn't
-	// introspect — it's expired / revoked / signed with a rotated
-	// key, and forwarding it to the schedd would just trigger a
-	// signature-verification error and a misleading 200 + JSON-RPC
-	// error envelope.
-	if h.oauth2Provider != nil &&
-		claims.Issuer == h.oauth2Provider.config.AccessTokenIssuer {
+	// Marker takes precedence over iss. A fosite-issued token whose
+	// row is gone from the DB (introspect fails) still carries
+	// token_use=mcp-oauth2, and we want a 401 — not a futile
+	// forward to the schedd.
+	if insp.TokenUse == MCPTokenUseMarker {
 		return tokenClassOurIDP
 	}
-	// HTCondor pool tokens carry iss == TRUST_DOMAIN. Anything else
-	// (an upstream OIDC provider whose introspection we don't
-	// support, a stale token from a previous deployment, etc.) is
-	// safer to 401 on than to silently forward.
-	if h.trustDomain != "" && claims.Issuer == h.trustDomain {
+	if insp.Issuer == "" {
+		return tokenClassUnknownIssuer
+	}
+	// Legacy / fallback: tokens minted before the marker existed,
+	// or external tokens. iss against our IDP wins over iss against
+	// TRUST_DOMAIN if they happen to differ.
+	if h.oauth2Provider != nil &&
+		insp.Issuer == h.oauth2Provider.config.AccessTokenIssuer {
+		return tokenClassOurIDP
+	}
+	if h.trustDomain != "" && insp.Issuer == h.trustDomain {
 		return tokenClassPoolIDToken
 	}
 	return tokenClassUnknownIssuer
@@ -2343,7 +2372,15 @@ func (h *Handler) generateHTCondorTokenWithScopes(username string, scopes []stri
 		"scopes", scopes,
 		"signing_key_path", h.signingKeyPath,
 	)
-	token, err := security.GenerateJWT(
+	// Mint via the local generator (NOT cedar's security.GenerateJWT)
+	// so we can attach a `token_use=mcp-oauth2` claim. That claim is
+	// invisible to the schedd's verifier (it ignores unknown claims)
+	// but lets our own auth classifier positively identify these
+	// tokens as ours and 401 them when fosite rejects on introspect.
+	// Without the marker, fosite-issued tokens are indistinguishable
+	// from condor_token_create output on iss/sub/kid — they're
+	// minted with the same pool key against the same trust domain.
+	token, err := generateMCPAccessJWT(
 		filepath.Dir(h.signingKeyPath),
 		filepath.Base(h.signingKeyPath),
 		username,

--- a/httpserver/mcp_token_classifier_test.go
+++ b/httpserver/mcp_token_classifier_test.go
@@ -1,0 +1,412 @@
+package httpserver
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/ory/fosite"
+)
+
+// These tests cover the gap that let the "claude.ai keeps presenting
+// an expired token, schedd 200s on a JSON-RPC error, no refresh ever
+// fires" bug ship. Two things needed coverage:
+//
+//   1. classifyUnknownToken — the heuristic that decides whether a
+//      fosite-rejected token should be forwarded to the schedd (real
+//      pool IDTOKEN) or surfaced as a 401 (our own expired token, or
+//      something we don't recognize). The OLD heuristic was "JWT-
+//      shaped → forward", which mismapped every OAuth2 access token
+//      we issue. The NEW heuristic compares the `iss` claim.
+//
+//   2. The WWW-Authenticate header on 401 must include the RFC 9728
+//      `resource_metadata` parameter when httpBaseURL is set, so
+//      MCP-spec clients can discover the authorization server and
+//      kick off a refresh.
+
+// makeJWT builds a syntactically valid JWT with the requested issuer.
+// Signature uses a throwaway HS256 key; the classifier never
+// verifies, so the key value doesn't matter — only the claims do.
+func makeJWT(t *testing.T, issuer string) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
+		Issuer:    issuer,
+		Subject:   "alice",
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	})
+	s, err := tok.SignedString([]byte("classifier-test-throwaway-key"))
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+	return s
+}
+
+// makeMarkedJWT mints a JWT carrying the MCP-OAuth2 sentinel claim
+// PLUS an arbitrary issuer. The combination matters: the classifier
+// must prefer the marker even when iss matches TRUST_DOMAIN (which
+// is the actual production case our log line surfaced).
+func makeMarkedJWT(t *testing.T, issuer string) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss":       issuer,
+		"sub":       "alice",
+		"iat":       time.Now().Unix(),
+		"exp":       time.Now().Add(time.Hour).Unix(),
+		"token_use": MCPTokenUseMarker,
+	})
+	s, err := tok.SignedString([]byte("classifier-test-throwaway-key"))
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+	return s
+}
+
+// testTrustDomain is the TRUST_DOMAIN value all classifier tests
+// use. Constant so the iss-comparison paths can refer to it as
+// "iss matches TRUST_DOMAIN" without re-stating it everywhere.
+const testTrustDomain = "ap40.example.com"
+
+// classifierTestHandler constructs the smallest Handler that can run
+// classifyUnknownToken: an OAuth2Provider with just the issuer set
+// and a fixed trust domain. No DB, no storage — those aren't touched
+// by the classifier. Pass an empty idpIssuer to simulate a server
+// running without OAuth2 (the oauth2Provider stays nil).
+func classifierTestHandler(idpIssuer string) *Handler {
+	h := &Handler{trustDomain: testTrustDomain}
+	if idpIssuer != "" {
+		h.oauth2Provider = &OAuth2Provider{
+			config: &fosite.Config{AccessTokenIssuer: idpIssuer},
+		}
+	}
+	return h
+}
+
+// TestClassifyUnknownTokenOurIDPRejected pins the bug-fix invariant:
+// a JWT whose `iss` matches our OAuth2 issuer must NOT be forwarded
+// to the schedd just because fosite rejected it. The classifier
+// returns tokenClassOurIDP and the caller's branch logic turns that
+// into a 401, which is what kicks claude.ai into a refresh flow.
+func TestClassifyUnknownTokenOurIDPRejected(t *testing.T) {
+	h := classifierTestHandler("https://ap40.example.com")
+	tok := makeJWT(t, "https://ap40.example.com")
+	got := h.classifyUnknownToken(tok)
+	if got != tokenClassOurIDP {
+		t.Errorf("classifyUnknownToken with our-IDP iss = %v, want tokenClassOurIDP", got)
+	}
+}
+
+// TestClassifyUnknownTokenPoolIDToken confirms that a JWT whose iss
+// matches TRUST_DOMAIN is still classified as a pool IDTOKEN that
+// the caller should hand to the schedd for verification. This is
+// the legitimate fall-through path — `condor_token_*`-fetched
+// tokens from CLI users, etc.
+func TestClassifyUnknownTokenPoolIDToken(t *testing.T) {
+	h := classifierTestHandler("https://ap40.example.com")
+	tok := makeJWT(t, "ap40.example.com")
+	got := h.classifyUnknownToken(tok)
+	if got != tokenClassPoolIDToken {
+		t.Errorf("classifyUnknownToken with TRUST_DOMAIN iss = %v, want tokenClassPoolIDToken", got)
+	}
+}
+
+// TestClassifyUnknownTokenForeignIssuer confirms that a JWT issued
+// by some third party (e.g. an upstream Google/Okta OIDC) gets
+// 401'd rather than silently shipped to the schedd. This is the
+// "anything we don't recognize is an auth failure" rule.
+func TestClassifyUnknownTokenForeignIssuer(t *testing.T) {
+	h := classifierTestHandler("https://ap40.example.com")
+	tok := makeJWT(t, "https://login.example.org")
+	got := h.classifyUnknownToken(tok)
+	if got != tokenClassUnknownIssuer {
+		t.Errorf("classifyUnknownToken with foreign iss = %v, want tokenClassUnknownIssuer", got)
+	}
+}
+
+// TestClassifyUnknownTokenUnparseable covers the case where the
+// presented Authorization value doesn't even decode as a JWT —
+// gibberish, an opaque-token cookie someone pasted by mistake, etc.
+// Must NOT panic and must NOT forward to the schedd.
+func TestClassifyUnknownTokenUnparseable(t *testing.T) {
+	h := classifierTestHandler("https://ap40.example.com")
+	for _, garbage := range []string{
+		"",
+		"not.a.jwt",
+		"abc.def",
+		"completelyrandomstring",
+	} {
+		got := h.classifyUnknownToken(garbage)
+		if got != tokenClassUnparseable && got != tokenClassUnknownIssuer {
+			t.Errorf("classifyUnknownToken(%q) = %v, want unparseable or unknown-issuer",
+				garbage, got)
+		}
+	}
+}
+
+// TestClassifyMarkedTokenWithTrustDomainIssuer is the
+// production-bug pin: a token carrying `token_use=mcp-oauth2` AND
+// iss=TRUST_DOMAIN (the OSG deployment shape) must classify as
+// tokenClassOurIDP and produce a 401, NOT pool-idtoken. Before the
+// marker, this combination forwarded to the schedd, the schedd
+// rejected the signature for unrelated reasons, and the MCP
+// response was a 200 with a JSON-RPC error so claude.ai never
+// refreshed. The marker reverses that decision.
+func TestClassifyMarkedTokenWithTrustDomainIssuer(t *testing.T) {
+	h := classifierTestHandler("https://ap40.example.com")
+	tok := makeMarkedJWT(t, testTrustDomain)
+	got := h.classifyUnknownToken(tok)
+	if got != tokenClassOurIDP {
+		t.Errorf("marked + iss==TRUST_DOMAIN classified as %v, want tokenClassOurIDP", got)
+	}
+}
+
+// TestClassifyMarkedTokenWithForeignIssuer confirms the marker is
+// the dominant signal even for unrecognized issuers. This shouldn't
+// happen in practice (our mint always uses TRUST_DOMAIN as iss) but
+// the safe behavior on a malformed-but-marked token is still to 401
+// it as ours rather than forward.
+func TestClassifyMarkedTokenWithForeignIssuer(t *testing.T) {
+	h := classifierTestHandler("https://ap40.example.com")
+	tok := makeMarkedJWT(t, "https://random.example.org")
+	got := h.classifyUnknownToken(tok)
+	if got != tokenClassOurIDP {
+		t.Errorf("marked + foreign iss classified as %v, want tokenClassOurIDP", got)
+	}
+}
+
+// TestClassifyUnmarkedTokenStillFallsBackToIssuer confirms tokens
+// minted BEFORE the marker landed (or genuine condor_token_create
+// output) still classify by iss. Without this back-compat path, a
+// real pool IDTOKEN — which never carries token_use — would 401
+// and break command-line condor_token_* clients.
+func TestClassifyUnmarkedTokenStillFallsBackToIssuer(t *testing.T) {
+	h := classifierTestHandler("https://ap40.example.com")
+	tok := makeJWT(t, testTrustDomain) // no token_use claim
+	got := h.classifyUnknownToken(tok)
+	if got != tokenClassPoolIDToken {
+		t.Errorf("unmarked + iss==TRUST_DOMAIN classified as %v, want tokenClassPoolIDToken", got)
+	}
+}
+
+// TestInspectTokenSurfacesTokenUse confirms the marker reaches the
+// log line. We log token_use on auth failures so an operator can
+// see WHY the classifier routed the way it did; if inspectToken
+// silently dropped the field the log signal would disappear too.
+func TestInspectTokenSurfacesTokenUse(t *testing.T) {
+	tok := makeMarkedJWT(t, testTrustDomain)
+	insp := inspectToken(tok)
+	if insp.TokenUse != MCPTokenUseMarker {
+		t.Errorf("TokenUse = %q, want %q", insp.TokenUse, MCPTokenUseMarker)
+	}
+}
+
+// TestGenerateMCPAccessJWTEmbedsMarker confirms our local minter
+// actually puts the marker into the issued token. This is the test
+// that catches "someone refactored the minter and forgot the
+// marker" — without it the classifier silently goes back to
+// forwarding our own tokens to the schedd.
+func TestGenerateMCPAccessJWTEmbedsMarker(t *testing.T) {
+	// We need a passwords.d/-style key file on disk. Use a fixed
+	// 32-byte payload — the minter XOR-unscrambles with 0xdeadbeef
+	// then runs HKDF; any bytes work for "did we end up with a JWT
+	// that has the marker?".
+	keyDir := t.TempDir()
+	keyPath := keyDir + "/POOL"
+	keyBytes := make([]byte, 32)
+	for i := range keyBytes {
+		keyBytes[i] = byte(i)
+	}
+	if err := writeKey(keyPath, keyBytes); err != nil {
+		t.Fatalf("writeKey: %v", err)
+	}
+
+	now := time.Now().Unix()
+	token, err := generateMCPAccessJWT(keyDir, "POOL",
+		"alice@example.com", testTrustDomain,
+		now, now+3600, []string{"READ"})
+	if err != nil {
+		t.Fatalf("generateMCPAccessJWT: %v", err)
+	}
+
+	insp := inspectToken(token)
+	if insp.TokenUse != MCPTokenUseMarker {
+		t.Errorf("minted token lacks token_use marker; got %q, want %q",
+			insp.TokenUse, MCPTokenUseMarker)
+	}
+	// Sanity-check the rest of the claims survived too — a future
+	// refactor that drops sub or iss on the way to adding the
+	// marker would still pass the marker check above.
+	if insp.Issuer != testTrustDomain {
+		t.Errorf("Issuer = %q, want %q", insp.Issuer, testTrustDomain)
+	}
+	if insp.Subject != "alice@example.com" {
+		t.Errorf("Subject = %q, want alice@example.com", insp.Subject)
+	}
+	if insp.KeyID != "POOL" {
+		t.Errorf("KeyID = %q, want POOL", insp.KeyID)
+	}
+}
+
+// writeKey writes a synthetic passwords.d/ key in HTCondor's
+// 0xdeadbeef-scrambled format. Just enough to drive
+// generateMCPAccessJWT in tests without depending on the cedar
+// key-generation helpers.
+func writeKey(path string, keyBytes []byte) error {
+	deadbeef := []byte{0xde, 0xad, 0xbe, 0xef}
+	scrambled := make([]byte, len(keyBytes))
+	for i := range keyBytes {
+		scrambled[i] = keyBytes[i] ^ deadbeef[i%len(deadbeef)]
+	}
+	return os.WriteFile(path, scrambled, 0o600)
+}
+
+// TestInspectTokenExtractsDiagnosticFields pins the
+// inspector that drives the "OAuth2 introspection rejected token"
+// log line's iss / sub / kid fields. Operators rely on these to
+// triage in production (they don't have the Bearer header in hand);
+// a refactor that quietly drops them would re-create the original
+// "we have no idea what was presented" problem.
+func TestInspectTokenExtractsDiagnosticFields(t *testing.T) {
+	// Build a JWT with iss, sub, AND a header.kid so we exercise
+	// every field the inspector reports.
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
+		Issuer:    "ap40.example.com",
+		Subject:   "alice@example.com",
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	})
+	tok.Header["kid"] = "POOL"
+	signed, err := tok.SignedString([]byte("inspector-test-key"))
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+
+	got := inspectToken(signed)
+	if got.Issuer != "ap40.example.com" {
+		t.Errorf("Issuer = %q, want ap40.example.com", got.Issuer)
+	}
+	if got.Subject != "alice@example.com" {
+		t.Errorf("Subject = %q, want alice@example.com", got.Subject)
+	}
+	if got.KeyID != "POOL" {
+		t.Errorf("KeyID = %q, want POOL", got.KeyID)
+	}
+}
+
+// TestInspectTokenZeroValueOnGarbage confirms inspectToken returns
+// the zero value (not a panic / partial population) when handed
+// something that doesn't parse. The auth log path tolerates empty
+// fields — they're themselves a signal — but a panic in the log
+// path would mask the actual failure with a 500.
+func TestInspectTokenZeroValueOnGarbage(t *testing.T) {
+	for _, bad := range []string{
+		"",
+		"not.a.jwt",
+		"abc",
+		"....",
+	} {
+		got := inspectToken(bad)
+		if got.Issuer != "" || got.Subject != "" || got.KeyID != "" {
+			t.Errorf("inspectToken(%q) = %+v, want zero value", bad, got)
+		}
+	}
+}
+
+// TestClassifyUnknownTokenNoOAuth2Provider covers a degraded
+// configuration: OAuth2 is disabled, so an "our IDP" check is
+// impossible. The classifier still needs to behave: TRUST_DOMAIN
+// matches still route as pool IDTOKEN, everything else is
+// unknown-issuer. The old code would have happily forwarded
+// anything 3-dot to the schedd here too.
+func TestClassifyUnknownTokenNoOAuth2Provider(t *testing.T) {
+	h := classifierTestHandler("")
+	if got := h.classifyUnknownToken(makeJWT(t, "ap40.example.com")); got != tokenClassPoolIDToken {
+		t.Errorf("no-oauth, TRUST_DOMAIN iss: got %v, want tokenClassPoolIDToken", got)
+	}
+	if got := h.classifyUnknownToken(makeJWT(t, "https://random.example")); got != tokenClassUnknownIssuer {
+		t.Errorf("no-oauth, foreign iss: got %v, want tokenClassUnknownIssuer", got)
+	}
+}
+
+// TestWWWAuthenticateIncludesResourceMetadata pins the RFC 9728
+// addition: when httpBaseURL is set, the WWW-Authenticate header
+// must carry a `resource_metadata="<base>/.well-known/oauth-protected-resource"`
+// parameter. claude.ai's MCP client reads that to discover the
+// authorization server and trigger refresh; without it the client
+// either errors out or stops talking.
+//
+// Verified against writeOAuthError (the 401 path) because that's
+// the only emitter on the auth-failure code path and it's the one
+// the MCP handler invokes.
+func TestWWWAuthenticateIncludesResourceMetadata(t *testing.T) {
+	server, err := NewServer(Config{
+		Logger:       newTestLogger(t),
+		EnableMCP:    true,
+		OAuth2DBPath: filepath.Join(t.TempDir(), "rfc9728.db"),
+		OAuth2Issuer: "https://ap40.example.com",
+		HTTPBaseURL:  "https://ap40.example.com",
+		ScheddName:   "test-schedd",
+		ScheddAddr:   "127.0.0.1:9618",
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	server.writeOAuthError(rr, 401, "invalid_token", "expired")
+	h := rr.Header().Get("WWW-Authenticate")
+	if h == "" {
+		t.Fatalf("missing WWW-Authenticate header")
+	}
+	wantSubstring := `resource_metadata="https://ap40.example.com/.well-known/oauth-protected-resource"`
+	if !strings.Contains(h, wantSubstring) {
+		t.Errorf("WWW-Authenticate missing %s\nfull header: %s", wantSubstring, h)
+	}
+	// Also confirm the legacy RFC 6750 pieces are still there — the
+	// MCP spec wants resource_metadata IN ADDITION TO, not instead of,
+	// realm/error/error_description.
+	for _, want := range []string{
+		`Bearer`,
+		`realm=`,
+		`error="invalid_token"`,
+		`error_description="expired"`,
+	} {
+		if !strings.Contains(h, want) {
+			t.Errorf("WWW-Authenticate missing legacy field %q\nfull header: %s", want, h)
+		}
+	}
+}
+
+// TestWWWAuthenticateOmitsResourceMetadataWhenNoBaseURL confirms we
+// don't emit a malformed/relative `resource_metadata` value when the
+// operator hasn't configured a public base URL. The header still
+// includes RFC 6750 fields so clients that don't understand RFC 9728
+// still get something usable.
+func TestWWWAuthenticateOmitsResourceMetadataWhenNoBaseURL(t *testing.T) {
+	server, err := NewServer(Config{
+		Logger:       newTestLogger(t),
+		EnableMCP:    true,
+		OAuth2DBPath: filepath.Join(t.TempDir(), "no-base.db"),
+		OAuth2Issuer: "https://ap40.example.com",
+		// HTTPBaseURL deliberately empty.
+		ScheddName: "test-schedd",
+		ScheddAddr: "127.0.0.1:9618",
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	server.writeOAuthError(rr, 401, "invalid_token", "expired")
+	h := rr.Header().Get("WWW-Authenticate")
+	if strings.Contains(h, "resource_metadata") {
+		t.Errorf("WWW-Authenticate carried resource_metadata despite empty httpBaseURL: %s", h)
+	}
+	if !strings.Contains(h, "Bearer") || !strings.Contains(h, "realm=") {
+		t.Errorf("WWW-Authenticate missing legacy fields when no base URL is set: %s", h)
+	}
+}

--- a/httpserver/mcp_token_mint.go
+++ b/httpserver/mcp_token_mint.go
@@ -1,0 +1,144 @@
+package httpserver
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// MCPTokenUseMarker is the value of the `token_use` JWT claim our
+// OAuth2 access tokens carry. It positively identifies a JWT as
+// minted by this server's OAuth2 flow (vs. an actual
+// condor_token_create-issued IDTOKEN), letting the auth path 401
+// our own expired/revoked tokens instead of forwarding them to the
+// schedd as if they were pool tokens.
+//
+// The HTCondor schedd ignores unknown JWT claims during signature
+// verification — it only checks iss/sub/scope/iat/exp/jti — so the
+// extra claim is invisible to anything outside this server.
+const MCPTokenUseMarker = "mcp-oauth2" //nolint:gosec // not a credential — public JWT-claim sentinel value, not a key/password
+
+// generateMCPAccessJWT mints an HTCondor-compatible JWT identical in
+// shape to cedar's security.GenerateJWT output PLUS a `token_use`
+// claim that lets our auth classifier positively identify these
+// tokens. We replicate cedar's logic locally (rather than calling
+// its GenerateJWT) for one reason: cedar's API doesn't accept
+// arbitrary extra claims. When that's fixed upstream this function
+// should collapse to a thin wrapper.
+//
+// The signing path is BYTE-IDENTICAL to cedar's:
+//
+//  1. Read scrambled key from keyDir/keyID
+//  2. XOR-unscramble with 0xdeadbeef
+//  3. If keyID == "POOL", duplicate the key bytes (an HTCondor
+//     quirk required for HKDF input)
+//  4. Derive a 32-byte HMAC key via HKDF(input, "htcondor",
+//     "master jwt")
+//  5. HS256(header || "." || payload, derived_key)
+//
+// Any deviation here would produce a token the schedd refuses to
+// verify; this function is tested against cedar's reference output
+// in TestGenerateMCPAccessJWTMatchesCedarShape.
+func generateMCPAccessJWT(
+	keyDir, keyID, subject, issuer string,
+	issuedAt, expiration int64,
+	authzLimits []string,
+) (string, error) {
+	// Read and unscramble the signing key — same on-disk format as
+	// HTCondor's passwords.d/ entries.
+	keyPath := filepath.Join(keyDir, keyID)
+	scrambled, err := os.ReadFile(keyPath) //nolint:gosec // operator-controlled path
+	if err != nil {
+		return "", fmt.Errorf("read signing key %s: %w", keyPath, err)
+	}
+	deadbeef := []byte{0xde, 0xad, 0xbe, 0xef}
+	signingKey := make([]byte, len(scrambled))
+	for i := range scrambled {
+		signingKey[i] = scrambled[i] ^ deadbeef[i%len(deadbeef)]
+	}
+
+	// POOL key duplication: HTCondor's POOL key derivation requires
+	// the input to be doubled before HKDF. See cedar/security for
+	// the original implementation.
+	hkdfInputKey := signingKey
+	if keyID == "POOL" {
+		hkdfInputKey = make([]byte, len(signingKey)*2)
+		copy(hkdfInputKey, signingKey)
+		copy(hkdfInputKey[len(signingKey):], signingKey)
+	}
+
+	// Random jti (16 bytes hex) — same as cedar.
+	jtiBytes := make([]byte, 16)
+	if _, err := rand.Read(jtiBytes); err != nil {
+		return "", fmt.Errorf("generate jti: %w", err)
+	}
+	jti := hex.EncodeToString(jtiBytes)
+
+	// JWT header — alg/typ/kid. Schedd reads kid to find the
+	// matching key in its passwords.d/.
+	header := map[string]string{
+		"alg": "HS256",
+		"typ": "JWT",
+		"kid": keyID,
+	}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("marshal header: %w", err)
+	}
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+
+	// Payload. Standard HTCondor IDTOKEN claims plus our sentinel.
+	// Key insertion order doesn't matter — JSON objects are
+	// unordered — but we use a map literal for readability.
+	payload := map[string]any{
+		"sub":       subject,
+		"jti":       jti,
+		"iat":       issuedAt,
+		"exp":       expiration,
+		"token_use": MCPTokenUseMarker, // <-- the marker
+	}
+	if issuer != "" {
+		payload["iss"] = issuer
+	}
+	if len(authzLimits) > 0 {
+		scopes := make([]string, len(authzLimits))
+		for i, limit := range authzLimits {
+			scopes[i] = "condor:/" + limit
+		}
+		payload["scope"] = strings.Join(scopes, " ")
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal payload: %w", err)
+	}
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	// Derive the HMAC key the same way cedar's GenerateJWT (and,
+	// crucially, the schedd's verifier) does it. Deviating from
+	// these constants — info / salt / output length — would
+	// produce a signature the schedd rejects.
+	signData := headerB64 + "." + payloadB64
+	const keyStrengthBytes = 32
+	jwtKey := make([]byte, keyStrengthBytes)
+	hkdfReader := hkdf.New(sha256.New, hkdfInputKey, []byte("htcondor"), []byte("master jwt"))
+	if _, err := io.ReadFull(hkdfReader, jwtKey); err != nil {
+		return "", fmt.Errorf("derive JWT key: %w", err)
+	}
+
+	mac := hmac.New(sha256.New, jwtKey)
+	mac.Write([]byte(signData))
+	signature := mac.Sum(nil)
+	signatureB64 := base64.RawURLEncoding.EncodeToString(signature)
+
+	return signData + "." + signatureB64, nil
+}

--- a/schedd.go
+++ b/schedd.go
@@ -525,10 +525,14 @@ func (s *Schedd) Submit(ctx context.Context, submitFileContent string) (string, 
 		return "", fmt.Errorf("failed to parse submit file: %w", err)
 	}
 
-	// Create QMGMT connection
+	// Create QMGMT connection. We propagate the error verbatim —
+	// NewQmgmtConnection already returns "failed to connect and
+	// authenticate to schedd at <addr>: …", so re-wrapping with
+	// "failed to connect to schedd at <addr>: …" here just produces
+	// the same address in two adjacent prefixes of the chain.
 	qmgmt, err := NewQmgmtConnection(ctx, s.address)
 	if err != nil {
-		return "", fmt.Errorf("failed to connect to schedd at %s: %w", s.address, err)
+		return "", err
 	}
 	defer func() {
 		if cerr := qmgmt.Close(); cerr != nil && err == nil {
@@ -614,10 +618,13 @@ func (s *Schedd) SubmitRemote(ctx context.Context, submitFileContent string) (cl
 		return 0, nil, fmt.Errorf("failed to parse submit file: %w", err)
 	}
 
-	// Connect to schedd's queue management interface
+	// Connect to schedd's queue management interface. Propagate the
+	// inner error verbatim; see the comment in Submit for why we
+	// don't re-wrap with another "failed to connect to schedd at ..."
+	// prefix.
 	qmgmt, err := NewQmgmtConnection(ctx, s.address)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to connect to schedd at %s: %w", s.address, err)
+		return 0, nil, err
 	}
 	defer func() {
 		if cerr := qmgmt.Close(); cerr != nil && err == nil {


### PR DESCRIPTION
Give more concise error messages when authorization with the AP fails; have a more reliable mechanism (stamping a custom claim) for detecting fosite-issued tokens.