### PR TITLE
Switch to using fosite-issued tokens

### DIFF
--- a/httpserver/mcp_handlers.go
+++ b/httpserver/mcp_handlers.go
@@ -334,10 +334,9 @@ func (h *Handler) validateOAuth2Token(r *http.Request) (fosite.AccessRequester, 
 // signature verifier); the marker is only used for routing the
 // HTTP response — 401-to-our-client vs. forward-to-schedd.
 type tokenInspection struct {
-	Issuer   string
-	Subject  string
-	KeyID    string // header.kid; identifies the signing key in passwords.d/
-	TokenUse string // "mcp-oauth2" on tokens this server's OAuth2 flow minted; "" on real condor IDTOKENs
+	Issuer  string
+	Subject string
+	KeyID   string // header.kid; identifies the signing key in passwords.d/
 }
 
 // inspectToken extracts the diagnostic-useful claims from a JWT
@@ -346,10 +345,6 @@ type tokenInspection struct {
 // parse returns the zero value — the caller's log will then show
 // empty fields, which is itself a useful signal (the Bearer wasn't
 // even a JWT).
-//
-// We parse with jwt.MapClaims so non-RFC-7519 claims like
-// `token_use` (our sentinel) are reachable. RegisteredClaims would
-// drop them silently.
 func inspectToken(tokenString string) tokenInspection {
 	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
 	parsed, _, err := parser.ParseUnverified(tokenString, jwt.MapClaims{})
@@ -363,9 +358,6 @@ func inspectToken(tokenString string) tokenInspection {
 		}
 		if v, ok := claims["sub"].(string); ok {
 			out.Subject = v
-		}
-		if v, ok := claims["token_use"].(string); ok {
-			out.TokenUse = v
 		}
 	}
 	// Header is a map[string]any; kid may be absent or non-string on
@@ -389,48 +381,38 @@ const (
 )
 
 // classifyUnknownToken decides whether a token fosite just rejected
-// should be forwarded to the schedd (real condor_token_create
-// output) or surfaced as a 401 (one of our own OAuth2 tokens that
-// expired / got revoked / was minted against a rotated key).
+// should be forwarded to the schedd (a real HTCondor IDTOKEN, e.g.
+// condor_token_fetch output from a CLI user) or surfaced as a 401.
 //
-// PRIMARY signal: the `token_use` claim. Our OAuth2 mint stamps
-// every access token with `token_use = MCPTokenUseMarker`; real
-// HTCondor IDTOKENs never carry this field. When present, the
-// token is positively identified as ours regardless of issuer —
-// which is what lets us distinguish in deployments where the
-// OAuth2 issuer is configured to equal TRUST_DOMAIN (both kinds
-// of token then have identical iss/sub/kid).
+// Our own MCP clients never reach this path: they present fosite's
+// opaque access token, which fosite introspects successfully. An
+// EXPIRED/revoked one fails introspection but isn't a JWT, so it
+// classifies as unparseable → 401, which is exactly what we want
+// (the client refreshes). Only genuine external IDTOKENs are JWTs
+// that warrant forwarding.
 //
-// FALLBACK signal: the `iss` claim, for tokens minted before the
-// marker was introduced and for genuinely-foreign tokens. If iss
-// matches the configured OAuth2 issuer we 401; if it matches
-// TRUST_DOMAIN we forward; otherwise we 401.
+// We classify by the `iss` claim:
+//   - matches our OAuth2 issuer → 401 (a stale token we minted before
+//     this server returned fosite tokens, or a forgery);
+//   - matches TRUST_DOMAIN → forward to the schedd for signature
+//     verification;
+//   - anything else → 401.
 //
 // The classifier never verifies the signature — fosite (already
 // failed) and the schedd (where forwarded tokens go) handle that.
-// Forging a `token_use` claim is therefore possible at this layer,
-// but the worst-case is "attacker's unsigned token gets 401'd
-// instead of also-401'd at the schedd"; no privilege escalation.
 func (h *Handler) classifyUnknownToken(tokenString string) tokenClass {
 	insp := inspectToken(tokenString)
-	if insp.Issuer == "" && insp.Subject == "" && insp.TokenUse == "" && insp.KeyID == "" {
+	if insp.Issuer == "" && insp.Subject == "" && insp.KeyID == "" {
 		// inspectToken returns zero value when the input isn't a
-		// parseable JWT at all. Treat as unparseable.
+		// parseable JWT at all (e.g. an opaque fosite access token).
+		// Treat as unparseable → 401.
 		return tokenClassUnparseable
-	}
-	// Marker takes precedence over iss. A fosite-issued token whose
-	// row is gone from the DB (introspect fails) still carries
-	// token_use=mcp-oauth2, and we want a 401 — not a futile
-	// forward to the schedd.
-	if insp.TokenUse == MCPTokenUseMarker {
-		return tokenClassOurIDP
 	}
 	if insp.Issuer == "" {
 		return tokenClassUnknownIssuer
 	}
-	// Legacy / fallback: tokens minted before the marker existed,
-	// or external tokens. iss against our IDP wins over iss against
-	// TRUST_DOMAIN if they happen to differ.
+	// iss against our IDP wins over iss against TRUST_DOMAIN if they
+	// happen to differ.
 	if h.oauth2Provider != nil &&
 		insp.Issuer == h.oauth2Provider.config.AccessTokenIssuer {
 		return tokenClassOurIDP
@@ -859,85 +841,14 @@ func (h *Handler) handleOAuth2Token(w http.ResponseWriter, r *http.Request) {
 	}
 	h.logger.Info(logging.DestinationHTTP, "Successfully created access response")
 
-	// Check if condor:/* scopes are requested
-	requestedScopes := accessRequest.GetRequestedScopes()
-	if hasCondorScopes(requestedScopes) {
-		// Generate HTCondor IDTOKEN and replace the access token
-		h.replaceWithCondorToken(ctx, w, r, accessRequest, response)
-		return
-	}
-
-	// Standard OAuth2 flow - write the response as-is
+	// Always return fosite's own access token — even for condor:/*
+	// scopes. The client uses this token against THIS server's MCP
+	// endpoint; we mint a short-lived HTCondor IDTOKEN on demand,
+	// per request, in handleMCPMessage to talk to the schedd. This
+	// keeps the credential the client holds introspectable and
+	// revocable by fosite, and means the client never carries a
+	// pool-signed token.
 	h.oauth2Provider.GetProvider().WriteAccessResponse(ctx, w, accessRequest, response)
-}
-
-// replaceWithCondorToken replaces the OAuth2 access token with an HTCondor IDTOKEN
-// while preserving the refresh token and other fields
-func (h *Handler) replaceWithCondorToken(ctx context.Context, w http.ResponseWriter, _ *http.Request, accessRequest fosite.AccessRequester, response fosite.AccessResponder) {
-	// Check if we can generate HTCondor tokens
-	if h.signingKeyPath == "" || h.trustDomain == "" {
-		h.logger.Error(logging.DestinationHTTP, "Cannot generate condor tokens: signing key or trust domain not configured")
-		err := &fosite.RFC6749Error{
-			ErrorField:       "server_error",
-			DescriptionField: "Server not configured to issue HTCondor tokens",
-			HintField:        "Contact administrator to configure signing key and trust domain",
-			CodeField:        http.StatusInternalServerError,
-		}
-		h.oauth2Provider.GetProvider().WriteAccessError(ctx, w, accessRequest, err)
-		return
-	}
-
-	// Get the username from the session
-	username := accessRequest.GetSession().GetSubject()
-	if username == "" {
-		h.logger.Error(logging.DestinationHTTP, "Cannot generate condor token: no username in session")
-		err := &fosite.RFC6749Error{
-			ErrorField:       "invalid_request",
-			DescriptionField: "Cannot determine user identity",
-			CodeField:        http.StatusBadRequest,
-		}
-		h.oauth2Provider.GetProvider().WriteAccessError(ctx, w, accessRequest, err)
-		return
-	}
-
-	// Get requested scopes
-	requestedScopes := accessRequest.GetRequestedScopes()
-
-	// Generate HTCondor IDTOKEN
-	idtoken, err := h.generateHTCondorTokenWithScopes(username, requestedScopes)
-	if err != nil {
-		h.logger.Error(logging.DestinationHTTP, "Failed to generate HTCondor IDTOKEN",
-			"error", err,
-			"username", username,
-			"scopes", requestedScopes)
-		fositeErr := &fosite.RFC6749Error{
-			ErrorField:       "server_error",
-			DescriptionField: "Failed to generate HTCondor IDTOKEN",
-			CodeField:        http.StatusInternalServerError,
-		}
-		h.oauth2Provider.GetProvider().WriteAccessError(ctx, w, accessRequest, fositeErr)
-		return
-	}
-
-	h.logger.Info(logging.DestinationHTTP, "Generated HTCondor IDTOKEN for condor scopes",
-		"username", username,
-		"scopes", requestedScopes)
-
-	// Get the response as a map and replace the access token with HTCondor IDTOKEN
-	// The response already has the refresh token and other OAuth2 fields
-	tokenResponse := response.ToMap()
-	h.logger.Info(logging.DestinationHTTP, "Token response map created", "has_refresh_token", tokenResponse["refresh_token"] != nil)
-	tokenResponse["access_token"] = idtoken
-	tokenResponse["token_type"] = "Bearer"
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("Pragma", "no-cache")
-	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(tokenResponse); err != nil {
-		h.logger.Error(logging.DestinationHTTP, "Failed to encode token response", "error", err)
-	}
 }
 
 // handleDeviceCodeTokenRequest handles token requests with device_code grant type
@@ -970,13 +881,6 @@ func (h *Handler) handleDeviceCodeTokenRequest(w http.ResponseWriter, r *http.Re
 		}
 		h.logger.Error(logging.DestinationHTTP, "Device code token request failed", "error", err)
 		h.writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "Invalid device code")
-		return
-	}
-
-	// Check if condor:/* scopes are requested - generate HTCondor IDTOKEN instead
-	grantedScopes := request.GetGrantedScopes()
-	if hasCondorScopes(grantedScopes) {
-		h.handleDeviceCodeCondorToken(ctx, w, r, request)
 		return
 	}
 
@@ -1029,83 +933,6 @@ func (h *Handler) handleDeviceCodeTokenRequest(w http.ResponseWriter, r *http.Re
 		"expires_in":    int(h.oauth2Provider.config.GetAccessTokenLifespan(ctx).Seconds()),
 		"refresh_token": refreshToken,
 		"scope":         strings.Join(request.GetGrantedScopes(), " "),
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("Pragma", "no-cache")
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		h.logger.Error(logging.DestinationHTTP, "Failed to encode response", "error", err)
-	}
-}
-
-// handleDeviceCodeCondorToken handles device code token requests when condor scopes are requested
-// It generates an HTCondor IDTOKEN instead of a standard OAuth2 access token
-func (h *Handler) handleDeviceCodeCondorToken(ctx context.Context, w http.ResponseWriter, _ *http.Request, request fosite.Requester) {
-	// Check if we can generate HTCondor tokens
-	if h.signingKeyPath == "" || h.trustDomain == "" {
-		h.logger.Error(logging.DestinationHTTP, "Cannot generate condor tokens: signing key or trust domain not configured")
-		h.writeOAuthError(w, http.StatusInternalServerError, "server_error", "Server not configured to issue HTCondor tokens")
-		return
-	}
-
-	// Get the username from the session
-	username := request.GetSession().GetSubject()
-	if username == "" {
-		h.logger.Error(logging.DestinationHTTP, "Cannot generate condor token: no username in session")
-		h.writeOAuthError(w, http.StatusBadRequest, "invalid_request", "Cannot determine user identity")
-		return
-	}
-
-	// Get granted scopes
-	grantedScopes := request.GetGrantedScopes()
-
-	// Generate HTCondor IDTOKEN
-	idtoken, err := h.generateHTCondorTokenWithScopes(username, grantedScopes)
-	if err != nil {
-		h.logger.Error(logging.DestinationHTTP, "Failed to generate HTCondor IDTOKEN",
-			"error", err,
-			"username", username,
-			"scopes", grantedScopes)
-		h.writeOAuthError(w, http.StatusInternalServerError, "server_error", "Failed to generate HTCondor IDTOKEN")
-		return
-	}
-
-	h.logger.Info(logging.DestinationHTTP, "Generated HTCondor IDTOKEN for device code flow",
-		"username", username,
-		"scopes", grantedScopes)
-
-	// Set per-token expiries on the session before generating the refresh token
-	// (see comment in handleDeviceCodeTokenRequest). The access token here is the
-	// HTCondor IDTOKEN, which has its own JWT-level expiry, but the refresh token
-	// still flows through fosite's HMAC strategy and needs the session expiry set.
-	setStandardTokenExpiries(ctx, h.oauth2Provider.config, request.GetSession())
-
-	// Generate refresh token using fosite
-	strategy := h.oauth2Provider.GetStrategy()
-	refreshToken, _, err := strategy.GenerateRefreshToken(ctx, request)
-	if err != nil {
-		h.logger.Error(logging.DestinationHTTP, "Failed to generate refresh token", "error", err)
-		h.writeOAuthError(w, http.StatusInternalServerError, "server_error", "Failed to generate token")
-		return
-	}
-
-	// Store the refresh token session
-	refreshSignature := strategy.RefreshTokenSignature(ctx, refreshToken)
-	if err := h.oauth2Provider.GetStorage().CreateRefreshTokenSession(ctx, refreshSignature, request); err != nil {
-		h.logger.Error(logging.DestinationHTTP, "Failed to store refresh token", "error", err)
-		h.writeOAuthError(w, http.StatusInternalServerError, "server_error", "Failed to store token")
-		return
-	}
-
-	// Build response with HTCondor IDTOKEN as access token
-	response := map[string]interface{}{
-		"access_token":  idtoken,
-		"token_type":    "Bearer",
-		"expires_in":    int(h.oauth2Provider.config.GetAccessTokenLifespan(ctx).Seconds()),
-		"refresh_token": refreshToken,
-		"scope":         strings.Join(grantedScopes, " "),
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -2318,6 +2145,12 @@ func mapCondorScopesToAuthz(scopes []string) []string {
 	return authz
 }
 
+// condorIDTokenLifetime is how long an on-demand HTCondor IDTOKEN is
+// valid. It's minted per request for a single schedd interaction and
+// never handed to the client, so it stays short; cedar's session cache
+// keeps subsequent requests from re-handshaking.
+const condorIDTokenLifetime = 5 * time.Minute
+
 // generateHTCondorTokenWithScopes generates an HTCondor token with scope-based permissions
 func (h *Handler) generateHTCondorTokenWithScopes(username string, scopes []string) (string, error) {
 	if h.signingKeyPath == "" {
@@ -2336,8 +2169,13 @@ func (h *Handler) generateHTCondorTokenWithScopes(username string, scopes []stri
 		username = username + "@" + h.uidDomain
 	}
 
+	// This IDTOKEN is minted on demand for a single schedd interaction
+	// and never handed to the client, so it can be short-lived. cedar
+	// caches the authenticated session after the first handshake, so a
+	// short expiry doesn't force a re-handshake mid-session; a fresh
+	// token is minted on the next cache-miss request anyway.
 	iat := time.Now().Unix()
-	exp := time.Now().Add(1 * time.Hour).Unix()
+	exp := time.Now().Add(condorIDTokenLifetime).Unix()
 
 	// Check if condor:/* scopes are present
 	var authz []string
@@ -2373,13 +2211,9 @@ func (h *Handler) generateHTCondorTokenWithScopes(username string, scopes []stri
 		"signing_key_path", h.signingKeyPath,
 	)
 	// Mint via the local generator (NOT cedar's security.GenerateJWT)
-	// so we can attach a `token_use=mcp-oauth2` claim. That claim is
-	// invisible to the schedd's verifier (it ignores unknown claims)
-	// but lets our own auth classifier positively identify these
-	// tokens as ours and 401 them when fosite rejects on introspect.
-	// Without the marker, fosite-issued tokens are indistinguishable
-	// from condor_token_create output on iss/sub/kid — they're
-	// minted with the same pool key against the same trust domain.
+	// so we can backdate the `nbf` claim to absorb clock skew between
+	// this server and the schedd (we've seen even 1s of skew cause
+	// rejections). The token is otherwise a standard HTCondor IDTOKEN.
 	token, err := generateMCPAccessJWT(
 		filepath.Dir(h.signingKeyPath),
 		filepath.Base(h.signingKeyPath),

--- a/httpserver/mcp_integration_test.go
+++ b/httpserver/mcp_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bbockelm/cedar/security"
 	"github.com/bbockelm/golang-htcondor/mcpserver"
 	"github.com/ory/fosite"
 	"golang.org/x/crypto/bcrypt"
@@ -188,7 +189,60 @@ func TestMCPHTTPIntegration(t *testing.T) {
 	t.Log("Step 6: Testing MCP job query...")
 	testMCPQueryJobs(t, client, baseURL, accessToken, clusterID)
 
+	// Step 7: Test the forward path — a raw HTCondor IDTOKEN (as a CLI
+	// user's condor_token_create / condor_token_fetch produces: pool-
+	// signed, iss=TRUST_DOMAIN, no OAuth2/token_use marker) presented
+	// directly to /mcp/message must be classified as a pool IDTOKEN and
+	// forwarded to the schedd, NOT 401'd.
+	t.Log("Step 7: Testing forward path with a raw HTCondor IDTOKEN...")
+	testMCPForwardRawCondorToken(t, client, baseURL, passwordsDir, trustDomain, testUser, clusterID)
+
 	t.Log("All MCP HTTP integration tests passed!")
+}
+
+// testMCPForwardRawCondorToken mints an HTCondor IDTOKEN with the pool
+// signing key (the same crypto condor_token_create uses) and presents it
+// directly to /mcp/message. This exercises validateOAuth2Token's
+// forward-to-schedd path: fosite can't introspect it, the classifier
+// sees iss==TRUST_DOMAIN with no marker and returns pool-idtoken, and the
+// handler hands the bearer to the schedd for authentication.
+func testMCPForwardRawCondorToken(t *testing.T, client *http.Client, baseURL, passwordsDir, trustDomain, user string, clusterID int) {
+	now := time.Now().Unix()
+	rawToken, err := security.GenerateJWT(
+		passwordsDir, "POOL",
+		user+"@"+trustDomain, trustDomain,
+		now, now+300,
+		[]string{"READ"},
+	)
+	if err != nil {
+		t.Fatalf("failed to mint raw HTCondor IDTOKEN: %v", err)
+	}
+
+	params := map[string]interface{}{
+		"name": "query_jobs",
+		"arguments": map[string]interface{}{
+			"constraint": fmt.Sprintf("ClusterId == %d", clusterID),
+			"projection": []string{"ClusterId", "ProcId", "JobStatus"},
+		},
+	}
+	paramsBytes, _ := json.Marshal(params)
+	mcpReq := mcpserver.MCPMessage{
+		JSONRPC: "2.0",
+		ID:      7,
+		Method:  "tools/call",
+		Params:  json.RawMessage(paramsBytes),
+	}
+
+	// sendMCPRequest already fails the test on a non-200 status, which is
+	// the key assertion: a 401 here would mean the forward path is broken.
+	mcpResp := sendMCPRequest(t, client, baseURL, rawToken, mcpReq)
+	if mcpResp.Error != nil {
+		t.Fatalf("query_jobs via raw IDTOKEN returned an error: %v", mcpResp.Error.Message)
+	}
+	if _, ok := mcpResp.Result.(map[string]interface{}); !ok {
+		t.Fatalf("query_jobs via raw IDTOKEN returned no result map: %+v", mcpResp.Result)
+	}
+	t.Log("Raw HTCondor IDTOKEN was forwarded to the schedd and authenticated successfully")
 }
 
 // createOAuth2Client creates a new OAuth2 client in the storage

--- a/httpserver/mcp_message_auth_test.go
+++ b/httpserver/mcp_message_auth_test.go
@@ -1,0 +1,81 @@
+package httpserver
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bbockelm/golang-htcondor/logging"
+)
+
+// newAuthTestHandler builds a Handler with a real fosite OAuth2 provider
+// (throwaway SQLite DB) and a quiet logger — enough to exercise
+// handleMCPMessage's auth gate without a schedd. trustDomain is set so
+// the classifier's "forward to schedd" branch is reachable in principle,
+// but the cases below deliberately never trigger it (that path needs a
+// live schedd and is covered by the integration suite).
+func newAuthTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	logger, err := logging.New(&logging.Config{OutputPath: "stderr"})
+	if err != nil {
+		t.Fatalf("logging.New: %v", err)
+	}
+	provider, err := NewOAuth2Provider(OAuth2ProviderOptions{
+		DB:                   newTestDB(t, filepath.Join(t.TempDir(), "auth.db")),
+		Issuer:               "https://mcp.example.com",
+		AccessTokenLifespan:  time.Hour,
+		RefreshTokenLifespan: 2 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewOAuth2Provider: %v", err)
+	}
+	t.Cleanup(func() { _ = provider.Close() })
+	return &Handler{
+		oauth2Provider: provider,
+		logger:         logger,
+		trustDomain:    "pool.example.com",
+	}
+}
+
+// TestMCPMessageRejectsBadTokenWith401 pins the contract that protects
+// MCP clients from the "expired token, 200 + JSON-RPC error, never
+// refreshes" failure mode: any bearer that fosite can't introspect and
+// that isn't a forwardable pool IDTOKEN must yield a real 401 from
+// /mcp/message. This covers the opaque-token case (an expired/unknown
+// fosite access token is opaque, so it parses as nothing → unparseable),
+// a foreign-issuer JWT, a stale JWT bearing our own issuer, and a
+// missing bearer.
+func TestMCPMessageRejectsBadTokenWith401(t *testing.T) {
+	h := newAuthTestHandler(t)
+
+	cases := []struct {
+		name   string
+		bearer string // "" means send no Authorization header
+	}{
+		{"opaque/garbage bearer (expired or unknown fosite token)", "ory_at_not-a-real-token"},
+		{"foreign-issuer JWT", makeJWT(t, "https://login.example.org")},
+		{"stale JWT bearing our own issuer", makeJWT(t, "https://mcp.example.com")},
+		{"missing bearer entirely", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp/message",
+				bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+			if tc.bearer != "" {
+				req.Header.Set("Authorization", "Bearer "+tc.bearer)
+			}
+			w := httptest.NewRecorder()
+
+			h.handleMCPMessage(w, req)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want 401 (body: %s)", w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/httpserver/mcp_scope_gate_test.go
+++ b/httpserver/mcp_scope_gate_test.go
@@ -1,0 +1,58 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bbockelm/golang-htcondor/mcpserver"
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/openid"
+)
+
+// TestIsMethodAllowedByScopes pins the OAuth2 scope gate that decides
+// whether a request's MCP method is permitted: mcp:write allows
+// everything, mcp:read allows read-only methods/tools only, and the
+// absence of either scope denies everything. "Read-only tool" is keyed
+// off mcpserver.IsReadOnlyTool, so query_jobs is allowed under read but
+// submit_job is not.
+func TestIsMethodAllowedByScopes(t *testing.T) {
+	h := &Handler{}
+
+	toolsCall := func(tool string) *mcpserver.MCPMessage {
+		return &mcpserver.MCPMessage{
+			Method: "tools/call",
+			Params: json.RawMessage(`{"name":"` + tool + `"}`),
+		}
+	}
+	method := func(m string) *mcpserver.MCPMessage {
+		return &mcpserver.MCPMessage{Method: m}
+	}
+
+	tests := []struct {
+		name   string
+		scopes []string
+		msg    *mcpserver.MCPMessage
+		want   bool
+	}{
+		{"read allows tools/list", []string{"mcp:read"}, method("tools/list"), true},
+		{"read allows a read-only tool", []string{"mcp:read"}, toolsCall("query_jobs"), true},
+		{"read denies a write tool", []string{"mcp:read"}, toolsCall("submit_job"), false},
+		{"write allows a write tool", []string{"mcp:write"}, toolsCall("submit_job"), true},
+		{"write allows a read tool", []string{"mcp:write"}, toolsCall("query_jobs"), true},
+		{"no scopes denies a read-only method", nil, method("tools/list"), false},
+		{"no scopes denies a read-only tool", nil, toolsCall("query_jobs"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ar := fosite.NewAccessRequest(&openid.DefaultSession{})
+			for _, s := range tt.scopes {
+				ar.GrantScope(s)
+			}
+			if got := h.isMethodAllowedByScopes(ar, tt.msg); got != tt.want {
+				t.Errorf("isMethodAllowedByScopes(scopes=%v, method=%q) = %v, want %v",
+					tt.scopes, tt.msg.Method, got, tt.want)
+			}
+		})
+	}
+}

--- a/httpserver/mcp_token_classifier_test.go
+++ b/httpserver/mcp_token_classifier_test.go
@@ -46,26 +46,6 @@ func makeJWT(t *testing.T, issuer string) string {
 	return s
 }
 
-// makeMarkedJWT mints a JWT carrying the MCP-OAuth2 sentinel claim
-// PLUS an arbitrary issuer. The combination matters: the classifier
-// must prefer the marker even when iss matches TRUST_DOMAIN (which
-// is the actual production case our log line surfaced).
-func makeMarkedJWT(t *testing.T, issuer string) string {
-	t.Helper()
-	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"iss":       issuer,
-		"sub":       "alice",
-		"iat":       time.Now().Unix(),
-		"exp":       time.Now().Add(time.Hour).Unix(),
-		"token_use": MCPTokenUseMarker,
-	})
-	s, err := tok.SignedString([]byte("classifier-test-throwaway-key"))
-	if err != nil {
-		t.Fatalf("SignedString: %v", err)
-	}
-	return s
-}
-
 // testTrustDomain is the TRUST_DOMAIN value all classifier tests
 // use. Constant so the iss-comparison paths can refer to it as
 // "iss matches TRUST_DOMAIN" without re-stating it everywhere.
@@ -147,73 +127,30 @@ func TestClassifyUnknownTokenUnparseable(t *testing.T) {
 	}
 }
 
-// TestClassifyMarkedTokenWithTrustDomainIssuer is the
-// production-bug pin: a token carrying `token_use=mcp-oauth2` AND
-// iss=TRUST_DOMAIN (the OSG deployment shape) must classify as
-// tokenClassOurIDP and produce a 401, NOT pool-idtoken. Before the
-// marker, this combination forwarded to the schedd, the schedd
-// rejected the signature for unrelated reasons, and the MCP
-// response was a 200 with a JSON-RPC error so claude.ai never
-// refreshed. The marker reverses that decision.
-func TestClassifyMarkedTokenWithTrustDomainIssuer(t *testing.T) {
+// TestClassifyTokenWithTrustDomainIssuerForwards confirms a genuine
+// external IDTOKEN (e.g. condor_token_fetch output from a CLI user),
+// whose iss==TRUST_DOMAIN, is forwarded to the schedd for signature
+// verification rather than 401'd. Our own MCP clients don't reach this
+// path — they present an opaque fosite token — so this is purely the
+// external-pool-token case.
+func TestClassifyTokenWithTrustDomainIssuerForwards(t *testing.T) {
 	h := classifierTestHandler("https://ap40.example.com")
-	tok := makeMarkedJWT(t, testTrustDomain)
-	got := h.classifyUnknownToken(tok)
-	if got != tokenClassOurIDP {
-		t.Errorf("marked + iss==TRUST_DOMAIN classified as %v, want tokenClassOurIDP", got)
-	}
-}
-
-// TestClassifyMarkedTokenWithForeignIssuer confirms the marker is
-// the dominant signal even for unrecognized issuers. This shouldn't
-// happen in practice (our mint always uses TRUST_DOMAIN as iss) but
-// the safe behavior on a malformed-but-marked token is still to 401
-// it as ours rather than forward.
-func TestClassifyMarkedTokenWithForeignIssuer(t *testing.T) {
-	h := classifierTestHandler("https://ap40.example.com")
-	tok := makeMarkedJWT(t, "https://random.example.org")
-	got := h.classifyUnknownToken(tok)
-	if got != tokenClassOurIDP {
-		t.Errorf("marked + foreign iss classified as %v, want tokenClassOurIDP", got)
-	}
-}
-
-// TestClassifyUnmarkedTokenStillFallsBackToIssuer confirms tokens
-// minted BEFORE the marker landed (or genuine condor_token_create
-// output) still classify by iss. Without this back-compat path, a
-// real pool IDTOKEN — which never carries token_use — would 401
-// and break command-line condor_token_* clients.
-func TestClassifyUnmarkedTokenStillFallsBackToIssuer(t *testing.T) {
-	h := classifierTestHandler("https://ap40.example.com")
-	tok := makeJWT(t, testTrustDomain) // no token_use claim
+	tok := makeJWT(t, testTrustDomain)
 	got := h.classifyUnknownToken(tok)
 	if got != tokenClassPoolIDToken {
-		t.Errorf("unmarked + iss==TRUST_DOMAIN classified as %v, want tokenClassPoolIDToken", got)
+		t.Errorf("iss==TRUST_DOMAIN classified as %v, want tokenClassPoolIDToken", got)
 	}
 }
 
-// TestInspectTokenSurfacesTokenUse confirms the marker reaches the
-// log line. We log token_use on auth failures so an operator can
-// see WHY the classifier routed the way it did; if inspectToken
-// silently dropped the field the log signal would disappear too.
-func TestInspectTokenSurfacesTokenUse(t *testing.T) {
-	tok := makeMarkedJWT(t, testTrustDomain)
-	insp := inspectToken(tok)
-	if insp.TokenUse != MCPTokenUseMarker {
-		t.Errorf("TokenUse = %q, want %q", insp.TokenUse, MCPTokenUseMarker)
-	}
-}
-
-// TestGenerateMCPAccessJWTEmbedsMarker confirms our local minter
-// actually puts the marker into the issued token. This is the test
-// that catches "someone refactored the minter and forgot the
-// marker" — without it the classifier silently goes back to
-// forwarding our own tokens to the schedd.
-func TestGenerateMCPAccessJWTEmbedsMarker(t *testing.T) {
+// TestGenerateMCPAccessJWTBackdatesNotBefore confirms our local minter
+// (a) backdates the `nbf` claim by nbfClockSkewLeeway so the schedd
+// won't reject the token over small clock skew, (b) carries the
+// expected diagnostic claims, and (c) no longer stamps the retired
+// token_use marker.
+func TestGenerateMCPAccessJWTBackdatesNotBefore(t *testing.T) {
 	// We need a passwords.d/-style key file on disk. Use a fixed
 	// 32-byte payload — the minter XOR-unscrambles with 0xdeadbeef
-	// then runs HKDF; any bytes work for "did we end up with a JWT
-	// that has the marker?".
+	// then runs HKDF; any bytes work for inspecting the claims.
 	keyDir := t.TempDir()
 	keyPath := keyDir + "/POOL"
 	keyBytes := make([]byte, 32)
@@ -224,22 +161,38 @@ func TestGenerateMCPAccessJWTEmbedsMarker(t *testing.T) {
 		t.Fatalf("writeKey: %v", err)
 	}
 
-	now := time.Now().Unix()
+	iat := time.Now().Unix()
 	token, err := generateMCPAccessJWT(keyDir, "POOL",
 		"alice@example.com", testTrustDomain,
-		now, now+3600, []string{"READ"})
+		iat, iat+3600, []string{"READ"})
 	if err != nil {
 		t.Fatalf("generateMCPAccessJWT: %v", err)
 	}
 
-	insp := inspectToken(token)
-	if insp.TokenUse != MCPTokenUseMarker {
-		t.Errorf("minted token lacks token_use marker; got %q, want %q",
-			insp.TokenUse, MCPTokenUseMarker)
+	// Decode the claims directly to inspect nbf / token_use, which
+	// inspectToken doesn't surface.
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsed, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("ParseUnverified: %v", err)
 	}
-	// Sanity-check the rest of the claims survived too — a future
-	// refactor that drops sub or iss on the way to adding the
-	// marker would still pass the marker check above.
+	claims := parsed.Claims.(jwt.MapClaims)
+
+	nbf, ok := claims["nbf"].(float64)
+	if !ok {
+		t.Fatalf("minted token missing nbf claim; claims=%v", claims)
+	}
+	wantNbf := iat - int64(nbfClockSkewLeeway.Seconds())
+	if int64(nbf) != wantNbf {
+		t.Errorf("nbf = %d, want %d (iat %d backdated by %s)",
+			int64(nbf), wantNbf, iat, nbfClockSkewLeeway)
+	}
+	if _, present := claims["token_use"]; present {
+		t.Errorf("minted token still carries retired token_use claim: %v", claims["token_use"])
+	}
+
+	// Sanity-check the diagnostic claims survived.
+	insp := inspectToken(token)
 	if insp.Issuer != testTrustDomain {
 		t.Errorf("Issuer = %q, want %q", insp.Issuer, testTrustDomain)
 	}

--- a/httpserver/mcp_token_mint.go
+++ b/httpserver/mcp_token_mint.go
@@ -12,29 +12,24 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/crypto/hkdf"
 )
 
-// MCPTokenUseMarker is the value of the `token_use` JWT claim our
-// OAuth2 access tokens carry. It positively identifies a JWT as
-// minted by this server's OAuth2 flow (vs. an actual
-// condor_token_create-issued IDTOKEN), letting the auth path 401
-// our own expired/revoked tokens instead of forwarding them to the
-// schedd as if they were pool tokens.
-//
-// The HTCondor schedd ignores unknown JWT claims during signature
-// verification — it only checks iss/sub/scope/iat/exp/jti — so the
-// extra claim is invisible to anything outside this server.
-const MCPTokenUseMarker = "mcp-oauth2" //nolint:gosec // not a credential — public JWT-claim sentinel value, not a key/password
+// nbfClockSkewLeeway backdates the `nbf` (not-before) claim on minted
+// IDTOKENs. The schedd rejects a token whose nbf is in its future, and
+// we've observed even ~1s of clock skew between this server and the
+// schedd cause spurious rejections; backdating by a few seconds
+// absorbs that skew without meaningfully widening the token's validity.
+const nbfClockSkewLeeway = 10 * time.Second
 
 // generateMCPAccessJWT mints an HTCondor-compatible JWT identical in
-// shape to cedar's security.GenerateJWT output PLUS a `token_use`
-// claim that lets our auth classifier positively identify these
-// tokens. We replicate cedar's logic locally (rather than calling
-// its GenerateJWT) for one reason: cedar's API doesn't accept
-// arbitrary extra claims. When that's fixed upstream this function
-// should collapse to a thin wrapper.
+// shape to cedar's security.GenerateJWT output, PLUS a backdated `nbf`
+// claim (see nbfClockSkewLeeway). We replicate cedar's logic locally
+// (rather than calling its GenerateJWT) for one reason: cedar's API
+// doesn't let us set nbf / arbitrary claims. When that's fixed
+// upstream this function should collapse to a thin wrapper.
 //
 // The signing path is BYTE-IDENTICAL to cedar's:
 //
@@ -97,15 +92,16 @@ func generateMCPAccessJWT(
 	}
 	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
 
-	// Payload. Standard HTCondor IDTOKEN claims plus our sentinel.
-	// Key insertion order doesn't matter — JSON objects are
-	// unordered — but we use a map literal for readability.
+	// Payload. Standard HTCondor IDTOKEN claims. `nbf` is backdated by
+	// nbfClockSkewLeeway so the schedd doesn't reject the token over
+	// small clock differences. Key insertion order doesn't matter —
+	// JSON objects are unordered — but we use a map literal for clarity.
 	payload := map[string]any{
-		"sub":       subject,
-		"jti":       jti,
-		"iat":       issuedAt,
-		"exp":       expiration,
-		"token_use": MCPTokenUseMarker, // <-- the marker
+		"sub": subject,
+		"jti": jti,
+		"iat": issuedAt,
+		"nbf": issuedAt - int64(nbfClockSkewLeeway.Seconds()),
+		"exp": expiration,
 	}
 	if issuer != "" {
 		payload["iss"] = issuer

--- a/httpserver/mcp_token_mint_test.go
+++ b/httpserver/mcp_token_mint_test.go
@@ -1,0 +1,99 @@
+package httpserver
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bbockelm/cedar/security"
+	"golang.org/x/crypto/hkdf"
+)
+
+// htcondorSignatureValid is a deliberately INDEPENDENT reimplementation
+// of HTCondor's IDTOKEN signing path (the one the schedd verifies
+// against): unscramble the on-disk key, double it for the POOL key, run
+// HKDF, then HMAC-SHA256 over header.payload. Because it re-derives the
+// constants itself rather than calling generateMCPAccessJWT, a drift in
+// either the minter's HKDF parameters or its POOL-doubling rule makes
+// this return false.
+func htcondorSignatureValid(t *testing.T, keyDir, keyID, token string) bool {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token is not a 3-part JWT (%d parts)", len(parts))
+	}
+	scrambled, err := os.ReadFile(filepath.Join(keyDir, keyID)) //nolint:gosec // test key path under t.TempDir()
+	if err != nil {
+		t.Fatalf("read key %s/%s: %v", keyDir, keyID, err)
+	}
+	deadbeef := []byte{0xde, 0xad, 0xbe, 0xef}
+	key := make([]byte, len(scrambled))
+	for i := range scrambled {
+		key[i] = scrambled[i] ^ deadbeef[i%len(deadbeef)]
+	}
+	hkdfInput := key
+	if keyID == "POOL" {
+		hkdfInput = append(append([]byte{}, key...), key...)
+	}
+	derived := make([]byte, 32)
+	if _, err := io.ReadFull(
+		hkdf.New(sha256.New, hkdfInput, []byte("htcondor"), []byte("master jwt")),
+		derived,
+	); err != nil {
+		t.Fatalf("hkdf: %v", err)
+	}
+	mac := hmac.New(sha256.New, derived)
+	mac.Write([]byte(parts[0] + "." + parts[1]))
+	want := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(want), []byte(parts[2]))
+}
+
+// TestGenerateMCPAccessJWTMatchesCedarShape pins that our local minter
+// produces tokens signed identically to cedar's security.GenerateJWT —
+// the library the schedd uses to verify IDTOKENs. We can't byte-compare
+// the two tokens (random jti, our extra nbf claim), so instead we prove
+// both are signed by the same HTCondor key derivation: an independent
+// verifier must accept BOTH. The integration suite proves the schedd
+// accepts our tokens end to end; this is the fast unit-level guard that
+// pinpoints signing drift without spinning up a daemon.
+func TestGenerateMCPAccessJWTMatchesCedarShape(t *testing.T) {
+	keyDir := t.TempDir()
+	keyBytes := make([]byte, 32)
+	for i := range keyBytes {
+		keyBytes[i] = byte(i*7 + 1)
+	}
+	if err := writeKey(filepath.Join(keyDir, "POOL"), keyBytes); err != nil {
+		t.Fatalf("writeKey: %v", err)
+	}
+
+	const sub = "alice@example.com"
+	iat := time.Now().Unix()
+	exp := iat + 300
+
+	ours, err := generateMCPAccessJWT(keyDir, "POOL", sub, testTrustDomain, iat, exp, []string{"READ", "WRITE"})
+	if err != nil {
+		t.Fatalf("generateMCPAccessJWT: %v", err)
+	}
+	ref, err := security.GenerateJWT(keyDir, "POOL", sub, testTrustDomain, iat, exp, []string{"READ", "WRITE"})
+	if err != nil {
+		t.Fatalf("security.GenerateJWT: %v", err)
+	}
+
+	// Sanity check: the independent verifier must accept cedar's OWN
+	// token. If it doesn't, the verifier is wrong and the assertion
+	// below would be meaningless.
+	if !htcondorSignatureValid(t, keyDir, "POOL", ref) {
+		t.Fatal("independent verifier rejected cedar's reference token; the verifier is wrong")
+	}
+	// The real assertion: our minted token verifies under the identical
+	// HTCondor key derivation, so the schedd will accept its signature.
+	if !htcondorSignatureValid(t, keyDir, "POOL", ours) {
+		t.Error("minted token signature does not verify under HTCondor key derivation; minter has drifted from cedar")
+	}
+}

--- a/httpserver/oauth2_condor_integration_test.go
+++ b/httpserver/oauth2_condor_integration_test.go
@@ -152,10 +152,11 @@ func TestCondorScopesIntegration(t *testing.T) {
 			token, refreshToken := getOAuth2TokenWithCondorScopes(t, httpClient, baseURL, clientID, clientSecret, "testuser", []string{"condor:/READ"})
 			t.Logf("Received access token: %s...", token[:min(50, len(token))])
 
-			// Verify the token is a JWT (3 parts separated by dots)
-			parts := strings.Split(token, ".")
-			if len(parts) != 3 {
-				t.Errorf("Token should be a JWT with 3 parts, got %d parts", len(parts))
+			// The access token is now fosite's own opaque token — the
+			// HTCondor IDTOKEN is minted server-side per request, never
+			// handed to the client — so it is NOT a 3-part JWT.
+			if token == "" {
+				t.Error("Access token should not be empty")
 			}
 
 			// Verify refresh token is present
@@ -169,10 +170,11 @@ func TestCondorScopesIntegration(t *testing.T) {
 			token, refreshToken := getOAuth2TokenWithCondorScopes(t, httpClient, baseURL, clientID, clientSecret, "testuser", []string{"condor:/WRITE"})
 			t.Logf("Received access token: %s...", token[:min(50, len(token))])
 
-			// Verify the token is a JWT
-			parts := strings.Split(token, ".")
-			if len(parts) != 3 {
-				t.Errorf("Token should be a JWT with 3 parts, got %d parts", len(parts))
+			// The access token is now fosite's own opaque token — the
+			// HTCondor IDTOKEN is minted server-side per request, never
+			// handed to the client — so it is NOT a 3-part JWT.
+			if token == "" {
+				t.Error("Access token should not be empty")
 			}
 
 			// Verify refresh token is present
@@ -187,10 +189,11 @@ func TestCondorScopesIntegration(t *testing.T) {
 			token, refreshToken := getOAuth2TokenWithCondorScopes(t, httpClient, baseURL, clientID, clientSecret, "testuser", scopes)
 			t.Logf("Received access token: %s...", token[:min(50, len(token))])
 
-			// Verify the token is a JWT
-			parts := strings.Split(token, ".")
-			if len(parts) != 3 {
-				t.Errorf("Token should be a JWT with 3 parts, got %d parts", len(parts))
+			// The access token is now fosite's own opaque token — the
+			// HTCondor IDTOKEN is minted server-side per request, never
+			// handed to the client — so it is NOT a 3-part JWT.
+			if token == "" {
+				t.Error("Access token should not be empty")
 			}
 
 			// Verify refresh token is present
@@ -218,10 +221,10 @@ func TestCondorScopesIntegration(t *testing.T) {
 			newToken := refreshOAuth2Token(t, httpClient, baseURL, clientID, clientSecret, refreshToken)
 			t.Logf("Refreshed access token: %s...", newToken[:min(50, len(newToken))])
 
-			// Verify the new token is also a JWT
-			parts := strings.Split(newToken, ".")
-			if len(parts) != 3 {
-				t.Errorf("Refreshed token should be a JWT with 3 parts, got %d parts", len(parts))
+			// The refreshed access token is likewise an opaque fosite
+			// token, not a 3-part JWT.
+			if newToken == "" {
+				t.Error("Refreshed access token should not be empty")
 			}
 
 			// Tokens should be different (different timestamps at minimum)


### PR DESCRIPTION
Instead of overriding fosite's token with an IDTOKEN, use fosite exclusively for client<->MCP communications.  Then, when a token has been verified, an in-memory IDTOKEN is generated to establish the remote session.

This way, fosite always can identify the token (and reject, as needed) when it is presented.