### PR TITLE
Fix advertising of available offline_access scope

### DIFF
--- a/httpserver/mcp_handlers.go
+++ b/httpserver/mcp_handlers.go
@@ -1068,16 +1068,20 @@ func (h *Handler) handleOAuth2Register(w http.ResponseWriter, r *http.Request) {
 		regReq.ResponseTypes = []string{"code"}
 	}
 	if len(regReq.Scopes) == 0 {
-		regReq.Scopes = []string{"openid", "profile", "email", "mcp:read", "mcp:write"}
+		regReq.Scopes = []string{"openid", "profile", "email", "offline_access", "mcp:read", "mcp:write"}
 	}
 
-	// Validate requested scopes against supported scopes
+	// Validate requested scopes against supported scopes. offline_access
+	// must be accepted and registered on the client; without it in the
+	// client's allowed set, filterScopesForClient strips it at authorize
+	// time and fosite never issues a refresh token.
 	supportedScopes := map[string]bool{
-		"openid":    true,
-		"profile":   true,
-		"email":     true,
-		"mcp:read":  true,
-		"mcp:write": true,
+		"openid":         true,
+		"profile":        true,
+		"email":          true,
+		"offline_access": true,
+		"mcp:read":       true,
+		"mcp:write":      true,
 	}
 	for _, scope := range regReq.Scopes {
 		// Allow condor:/* scopes
@@ -1135,6 +1139,20 @@ func generateRandomString(length int) string {
 	return hex.EncodeToString(b)
 }
 
+// oauth2AdvertisedScopes is the scope set published in both OAuth2
+// discovery documents (authorization-server and protected-resource
+// metadata). offline_access MUST be advertised: clients like claude.ai
+// only request the scopes the server advertises, so without it here they
+// never ask for a refresh token and silently end up with access-token-
+// only sessions that force a full re-auth on every expiry.
+var oauth2AdvertisedScopes = []string{
+	"openid", "profile", "email",
+	"offline_access",
+	"mcp:read", "mcp:write",
+	"condor:/READ", "condor:/WRITE",
+	"condor:/ADVERTISE_STARTD", "condor:/ADVERTISE_SCHEDD", "condor:/ADVERTISE_MASTER",
+}
+
 // handleOAuth2Metadata handles OAuth2 authorization server metadata discovery
 // Implements RFC 8414: OAuth 2.0 Authorization Server Metadata
 func (h *Handler) handleOAuth2Metadata(w http.ResponseWriter, _ *http.Request) {
@@ -1158,7 +1176,7 @@ func (h *Handler) handleOAuth2Metadata(w http.ResponseWriter, _ *http.Request) {
 		"grant_types_supported":                 []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
 		"subject_types_supported":               []string{"public"},
 		"id_token_signing_alg_values_supported": []string{"RS256"},
-		"scopes_supported":                      []string{"openid", "profile", "email", "mcp:read", "mcp:write", "condor:/READ", "condor:/WRITE", "condor:/ADVERTISE_STARTD", "condor:/ADVERTISE_SCHEDD", "condor:/ADVERTISE_MASTER"},
+		"scopes_supported":                      oauth2AdvertisedScopes,
 		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post"},
 		"code_challenge_methods_supported":      []string{"plain", "S256"},
 	}
@@ -1187,7 +1205,7 @@ func (h *Handler) handleOAuth2ProtectedResourceMetadata(w http.ResponseWriter, _
 		"authorization_servers":                 []string{issuer},
 		"bearer_methods_supported":              []string{"header"},
 		"resource_signing_alg_values_supported": []string{"RS256"},
-		"scopes_supported":                      []string{"openid", "profile", "email", "mcp:read", "mcp:write", "condor:/READ", "condor:/WRITE", "condor:/ADVERTISE_STARTD", "condor:/ADVERTISE_SCHEDD", "condor:/ADVERTISE_MASTER"},
+		"scopes_supported":                      oauth2AdvertisedScopes,
 		"resource_documentation":                issuer + "/mcp",
 	}
 

--- a/httpserver/mcp_handlers_test.go
+++ b/httpserver/mcp_handlers_test.go
@@ -247,6 +247,77 @@ func TestDynamicClientRegistrationScopeFormats(t *testing.T) {
 	}
 }
 
+// TestDynamicClientRegistrationGrantsOfflineAccess pins the fix that lets
+// refresh tokens work: a dynamically-registered client must be allowed
+// the offline_access scope. If it isn't, filterScopesForClient strips
+// offline_access at authorize time and fosite never issues a refresh
+// token — the bug that left claude.ai re-authenticating on every expiry.
+// The registration response's scope mirrors the stored client scopes, so
+// asserting on it proves what the client is registered with.
+func TestDynamicClientRegistrationGrantsOfflineAccess(t *testing.T) {
+	logger, err := logging.New(&logging.Config{OutputPath: "stderr"})
+	if err != nil {
+		t.Fatalf("logging.New: %v", err)
+	}
+	server, err := NewServer(Config{
+		Logger:       logger,
+		EnableMCP:    true,
+		OAuth2DBPath: filepath.Join(t.TempDir(), "reg.db"),
+		OAuth2Issuer: "http://localhost:8080",
+		ScheddName:   "test-schedd",
+		ScheddAddr:   "127.0.0.1:9618",
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	register := func(t *testing.T, body map[string]interface{}) []string {
+		t.Helper()
+		reqBody, _ := json.Marshal(body)
+		req := httptest.NewRequestWithContext(context.Background(), "POST", "/mcp/oauth2/register", bytes.NewReader(reqBody))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		server.handleOAuth2Register(rr, req)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("registration failed: status %d, body %s", rr.Code, rr.Body.String())
+		}
+		var resp map[string]interface{}
+		if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		return strings.Fields(resp["scope"].(string))
+	}
+
+	hasOffline := func(scopes []string) bool {
+		for _, s := range scopes {
+			if s == "offline_access" {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("explicitly requested offline_access is accepted", func(t *testing.T) {
+		scopes := register(t, map[string]interface{}{
+			"redirect_uris": []string{"http://localhost:8080/callback"},
+			"scope":         "openid offline_access mcp:read",
+		})
+		if !hasOffline(scopes) {
+			t.Errorf("registered scopes %v missing offline_access (was it rejected/stripped?)", scopes)
+		}
+	})
+
+	t.Run("default scopes include offline_access", func(t *testing.T) {
+		scopes := register(t, map[string]interface{}{
+			"redirect_uris": []string{"http://localhost:8080/callback"},
+			// no scope -> server defaults apply
+		})
+		if !hasOffline(scopes) {
+			t.Errorf("default registered scopes %v missing offline_access", scopes)
+		}
+	})
+}
+
 // TestOAuth2MetadataScopes tests that the OAuth2 metadata includes all supported scopes
 func TestOAuth2MetadataScopes(t *testing.T) {
 	// Create temporary directory for test database
@@ -301,11 +372,12 @@ func TestOAuth2MetadataScopes(t *testing.T) {
 	}
 
 	expectedScopes := map[string]bool{
-		"openid":    false,
-		"profile":   false,
-		"email":     false,
-		"mcp:read":  false,
-		"mcp:write": false,
+		"openid":         false,
+		"profile":        false,
+		"email":          false,
+		"offline_access": false,
+		"mcp:read":       false,
+		"mcp:write":      false,
 	}
 
 	for _, scope := range scopesSupported {
@@ -318,7 +390,9 @@ func TestOAuth2MetadataScopes(t *testing.T) {
 		}
 	}
 
-	// Check all expected scopes are present
+	// Check all expected scopes are present. offline_access in particular
+	// must be advertised, or clients like claude.ai never request it and
+	// never receive a refresh token.
 	for scope, found := range expectedScopes {
 		if !found {
 			t.Errorf("Expected scope '%s' not found in scopes_supported", scope)
@@ -404,11 +478,12 @@ func TestOAuth2ProtectedResourceMetadata(t *testing.T) {
 	}
 
 	expectedScopes := map[string]bool{
-		"openid":    false,
-		"profile":   false,
-		"email":     false,
-		"mcp:read":  false,
-		"mcp:write": false,
+		"openid":         false,
+		"profile":        false,
+		"email":          false,
+		"offline_access": false,
+		"mcp:read":       false,
+		"mcp:write":      false,
 	}
 
 	for _, scope := range scopesSupported {

--- a/httpserver/mcp_integration_test.go
+++ b/httpserver/mcp_integration_test.go
@@ -197,7 +197,134 @@ func TestMCPHTTPIntegration(t *testing.T) {
 	t.Log("Step 7: Testing forward path with a raw HTCondor IDTOKEN...")
 	testMCPForwardRawCondorToken(t, client, baseURL, passwordsDir, trustDomain, testUser, clusterID)
 
+	// Step 8: A dynamically-registered client (RFC 7591) that requests
+	// offline_access must receive a refresh token. This is the end-to-end
+	// guard for the "claude.ai re-auths on every expiry" bug: the DCR
+	// endpoint must advertise+accept offline_access so it survives scope
+	// filtering and fosite issues a refresh token.
+	t.Log("Step 8: Testing refresh-token issuance for a dynamically-registered client...")
+	dcrID, dcrSecret := registerDCRClient(t, client, baseURL)
+	refreshTok := getRefreshTokenViaAuthCode(t, client, baseURL, dcrID, dcrSecret, testUser)
+	t.Logf("Refresh token issued to DCR client: %s...", refreshTok[:min(12, len(refreshTok))])
+
 	t.Log("All MCP HTTP integration tests passed!")
+}
+
+// registerDCRClient registers an OAuth2 client via the RFC 7591 dynamic
+// client registration endpoint, requesting offline_access, and returns
+// its credentials. It asserts the registered scope set actually includes
+// offline_access — if the server stripped or rejected it, no refresh
+// token could ever be issued to this client.
+func registerDCRClient(t *testing.T, httpClient *http.Client, baseURL string) (string, string) {
+	regBody, _ := json.Marshal(map[string]interface{}{
+		"redirect_uris":  []string{"http://localhost:18081/callback"},
+		"grant_types":    []string{"authorization_code", "refresh_token"},
+		"response_types": []string{"code"},
+		"scope":          "openid profile email offline_access mcp:read mcp:write",
+		"client_name":    "dcr-refresh-test",
+	})
+	req, _ := http.NewRequest("POST", baseURL+"/mcp/oauth2/register", bytes.NewReader(regBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("DCR request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("DCR failed: status %d, body %s", resp.StatusCode, string(body))
+	}
+	var reg struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+		Scope        string `json:"scope"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&reg); err != nil {
+		t.Fatalf("decode DCR response: %v", err)
+	}
+	if !strings.Contains(reg.Scope, "offline_access") {
+		t.Fatalf("DCR client not granted offline_access; scope=%q", reg.Scope)
+	}
+	return reg.ClientID, reg.ClientSecret
+}
+
+// getRefreshTokenViaAuthCode runs the full authorization-code flow for a
+// client, requesting offline_access, and returns the refresh token from
+// the token response. It fails the test if no refresh token was issued —
+// the regression this whole change guards against.
+func getRefreshTokenViaAuthCode(t *testing.T, httpClient *http.Client, baseURL, clientID, clientSecret, username string) string {
+	const scope = "openid profile email offline_access mcp:read mcp:write"
+	authURL := fmt.Sprintf("%s/mcp/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=http://localhost:18081/callback&scope=%s&state=teststate&username=%s",
+		baseURL, clientID, url.QueryEscape(scope), username)
+	req, _ := http.NewRequest("GET", authURL, nil)
+	req.Header.Set("X-Test-User", username)
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	defer func() { httpClient.CheckRedirect = nil }()
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("authorize request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	location := resp.Header.Get("Location")
+	if location == "" {
+		t.Fatal("no redirect location from authorize")
+	}
+
+	// Approve consent if redirected there.
+	if strings.Contains(location, "/mcp/oauth2/consent") {
+		u, err := url.Parse(location)
+		if err != nil {
+			t.Fatalf("parse consent URL: %v", err)
+		}
+		form := url.Values{}
+		form.Set("action", "approve")
+		form.Set("state", u.Query().Get("state"))
+		form.Set("scope", scope)
+		creq, _ := http.NewRequest("POST", baseURL+"/mcp/oauth2/consent", strings.NewReader(form.Encode()))
+		creq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		creq.Header.Set("X-Test-User", username)
+		cresp, err := httpClient.Do(creq)
+		if err != nil {
+			t.Fatalf("consent request failed: %v", err)
+		}
+		defer cresp.Body.Close()
+		location = cresp.Header.Get("Location")
+		if location == "" {
+			t.Fatal("no redirect location from consent")
+		}
+	}
+
+	code := extractCodeFromURL(t, location)
+	if code == "" {
+		t.Fatalf("no authorization code in redirect: %s", location)
+	}
+
+	tokenReq, _ := http.NewRequest("POST", baseURL+"/mcp/oauth2/token", bytes.NewBufferString(
+		fmt.Sprintf("grant_type=authorization_code&code=%s&redirect_uri=http://localhost:18081/callback&client_id=%s&client_secret=%s",
+			code, clientID, clientSecret)))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenResp, err := httpClient.Do(tokenReq)
+	if err != nil {
+		t.Fatalf("token request failed: %v", err)
+	}
+	defer tokenResp.Body.Close()
+	if tokenResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(tokenResp.Body)
+		t.Fatalf("token request failed: status %d, body %s", tokenResp.StatusCode, string(body))
+	}
+	var td struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		Scope        string `json:"scope"`
+	}
+	if err := json.NewDecoder(tokenResp.Body).Decode(&td); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	if td.RefreshToken == "" {
+		t.Fatalf("no refresh_token issued despite offline_access (granted scope=%q)", td.Scope)
+	}
+	return td.RefreshToken
 }
 
 // testMCPForwardRawCondorToken mints an HTCondor IDTOKEN with the pool


### PR DESCRIPTION
Without this, it appears claude.ai assumes it can't do a refresh flow.