### PR TITLE
config: read local config chain + subsystem/local-name scoping; daemon: adopt inherited command socket (#119)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -151,12 +152,27 @@ func NewFromReaderWithOptions(r io.Reader, opts ConfigOptions) (*Config, error) 
 	return cfg, nil
 }
 
-// Get retrieves a configuration value
+// Get retrieves a configuration value, honoring HTCondor's subsystem and
+// local-name prefix precedence. For a Config created with a Subsystem and/or
+// LocalName, a more specific definition overrides the bare parameter, most
+// specific first:
+//
+//	<SUBSYS>.<LOCALNAME>.<KEY>   (e.g. COLLECTOR.HTCVIEW.CONDOR_VIEW_HOST)
+//	<LOCALNAME>.<KEY>            (e.g. HTCVIEW.CONDOR_VIEW_HOST)
+//	<SUBSYS>.<KEY>               (e.g. COLLECTOR.CONDOR_VIEW_HOST)
+//	<KEY>                        (the bare parameter)
+//
+// This is what lets two daemons of the same subsystem run under one
+// condor_master with distinct config -- e.g. the stock C++ condor_collector and
+// an htc-collector view host (started with -local-name HTCVIEW) taking different
+// COLLECTOR_LOG, COLLECTOR_ADDRESS_FILE, and CONDOR_VIEW_HOST values.
 func (c *Config) Get(key string) (string, bool) {
 	// Check for macro expansion
 	if strings.HasPrefix(key, "$(") && strings.HasSuffix(key, ")") {
 		key = key[2 : len(key)-1]
 	}
+
+	key = c.scopedLookupKey(key)
 
 	val, ok := c.values[key]
 	if !ok {
@@ -170,6 +186,36 @@ func (c *Config) Get(key string) (string, bool) {
 	}
 
 	return expanded, true
+}
+
+// scopedLookupKey returns the most specific map key that exists for the bare
+// parameter name, applying the Config's subsystem/local-name prefixes in
+// HTCondor precedence order (see Get). It leaves an already-qualified key (one
+// containing '.') untouched so an explicit dotted lookup is not re-prefixed, and
+// returns key unchanged when neither subsystem nor local name is set or no scoped
+// definition exists.
+func (c *Config) scopedLookupKey(key string) string {
+	subsys, local := c.options.Subsystem, c.options.LocalName
+	if (subsys == "" && local == "") || strings.ContainsRune(key, '.') {
+		return key
+	}
+	// Most specific first; only override when a scoped definition actually exists.
+	if subsys != "" && local != "" {
+		if _, ok := c.values[subsys+"."+local+"."+key]; ok {
+			return subsys + "." + local + "." + key
+		}
+	}
+	if local != "" {
+		if _, ok := c.values[local+"."+key]; ok {
+			return local + "." + key
+		}
+	}
+	if subsys != "" {
+		if _, ok := c.values[subsys+"."+key]; ok {
+			return subsys + "." + key
+		}
+	}
+	return key
 }
 
 // Set sets a configuration value
@@ -1013,49 +1059,55 @@ func (c *Config) LoadFromEnvironment() error {
 		}
 	}
 
-	// Check for CONDOR_CONFIG
-	if configPath := os.Getenv("CONDOR_CONFIG"); configPath != "" {
-		if configPath == "ONLY_ENV" {
-			// Skip file loading
-			return nil
-		}
-
-		// Try to load the config file
-		//nolint:gosec // G304: Config path comes from validated environment/parameters
-		f, err := os.Open(configPath)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			if cerr := f.Close(); cerr != nil && err == nil {
-				err = fmt.Errorf("failed to close config file: %w", cerr)
+	// Locate the root configuration file: CONDOR_CONFIG, or a default location.
+	rootPath := os.Getenv("CONDOR_CONFIG")
+	if rootPath == "ONLY_ENV" {
+		// Explicit request to skip all file loading.
+		return nil
+	}
+	if rootPath == "" {
+		for _, path := range []string{"/etc/condor/condor_config", "/usr/local/etc/condor_config"} {
+			if _, err := os.Stat(path); err == nil {
+				rootPath = path
+				break
 			}
-		}()
-
-		return c.parseReader(f, configPath)
-	}
-
-	// Try default locations
-	defaultPaths := []string{
-		"/etc/condor/condor_config",
-		"/usr/local/etc/condor_config",
-	}
-
-	for _, path := range defaultPaths {
-		//nolint:gosec // G304: Checking known default config paths
-		f, err := os.Open(path)
-		if err == nil {
-			defer func() {
-				if cerr := f.Close(); cerr != nil && err == nil {
-					err = fmt.Errorf("failed to close config file: %w", cerr)
-				}
-			}()
-			return c.parseReader(f, path)
 		}
 	}
+	if rootPath == "" {
+		// No config file found, that's OK.
+		return nil
+	}
 
-	// No config file found, that's OK
-	return nil
+	if err := c.parseConfigFile(rootPath); err != nil {
+		return err
+	}
+
+	// HTCondor then reads the local configuration chain, with later sources
+	// overriding earlier ones: the LOCAL_CONFIG_DIR directories (config.d, files
+	// in lexicographic order) followed by the LOCAL_CONFIG_FILE list. Without
+	// this, anything defined there -- commonly LOG, LOCAL_DIR, security, and pool
+	// knobs on a production install -- is silently missed and the built-in
+	// param defaults win instead (e.g. LOG resolves to $(LOCAL_DIR)/log rather
+	// than the config.d override).
+	if err := c.processLocalConfigDir(); err != nil {
+		return err
+	}
+	return c.processLocalConfigFile()
+}
+
+// parseConfigFile opens and parses a single configuration file at path.
+func (c *Config) parseConfigFile(path string) (err error) {
+	//nolint:gosec // G304: config path comes from CONDOR_CONFIG / known defaults
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("failed to close config file: %w", cerr)
+		}
+	}()
+	return c.parseReader(f, path)
 }
 
 // processLocalConfigDir processes directories listed in LOCAL_CONFIG_DIR
@@ -1069,6 +1121,18 @@ func (c *Config) processLocalConfigDir() error {
 
 	// Split on comma and/or space
 	dirs := splitConfigList(dirList)
+
+	// Files whose basename matches LOCAL_CONFIG_DIR_EXCLUDE_REGEXP are skipped --
+	// this is how HTCondor keeps editor backups, package leftovers (.rpmnew,
+	// .dpkg-dist), and helper scripts (.py/.sh/.pl) out of config.d parsing. A
+	// config.d without this filter would try to parse those as config and fail or
+	// mis-set values.
+	var excludeRe *regexp.Regexp
+	if pat, ok := c.Get("LOCAL_CONFIG_DIR_EXCLUDE_REGEXP"); ok && pat != "" {
+		if re, err := regexp.Compile(pat); err == nil {
+			excludeRe = re
+		}
+	}
 
 	for _, dir := range dirs {
 		dir = strings.TrimSpace(dir)
@@ -1099,6 +1163,9 @@ func (c *Config) processLocalConfigDir() error {
 		for _, entry := range entries {
 			if entry.IsDir() {
 				continue // Skip subdirectories
+			}
+			if excludeRe != nil && excludeRe.MatchString(entry.Name()) {
+				continue // Excluded by LOCAL_CONFIG_DIR_EXCLUDE_REGEXP
 			}
 
 			filePath := filepath.Join(dir, entry.Name())
@@ -1155,6 +1222,13 @@ func (c *Config) processLocalConfigFile() error {
 		//nolint:gosec // G304: File path comes from validated config directive
 		f, err := os.Open(file)
 		if err != nil {
+			// A missing LOCAL_CONFIG_FILE is tolerated unless
+			// REQUIRE_LOCAL_CONFIG_FILE is true (HTCondor's shipped config sets it
+			// false and points LOCAL_CONFIG_FILE at a file that need not exist).
+			required, _ := c.Get("REQUIRE_LOCAL_CONFIG_FILE")
+			if os.IsNotExist(err) && !c.isTruthy(required) {
+				continue
+			}
 			return fmt.Errorf("error opening %s: %w", file, err)
 		}
 		err = c.parseAndExecute(f)

--- a/config/local_chain_scoping_test.go
+++ b/config/local_chain_scoping_test.go
@@ -16,7 +16,7 @@ import (
 func TestLoadFromEnvironmentProcessesLocalChain(t *testing.T) {
 	tmp := t.TempDir()
 	confd := filepath.Join(tmp, "config.d")
-	if err := os.MkdirAll(confd, 0o755); err != nil {
+	if err := os.MkdirAll(confd, 0o750); err != nil {
 		t.Fatal(err)
 	}
 

--- a/config/local_chain_scoping_test.go
+++ b/config/local_chain_scoping_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLoadFromEnvironmentProcessesLocalChain is the end-to-end guard for the bug
+// where LoadFromEnvironment read only the root config file and silently ignored
+// LOCAL_CONFIG_DIR (config.d) and LOCAL_CONFIG_FILE -- so LOG (or any knob)
+// defined there fell back to the param default (e.g. LOG=$(LOCAL_DIR)/log). It
+// also covers the LOCAL_CONFIG_DIR_EXCLUDE_REGEXP filter and tolerance of a
+// missing LOCAL_CONFIG_FILE entry.
+func TestLoadFromEnvironmentProcessesLocalChain(t *testing.T) {
+	tmp := t.TempDir()
+	confd := filepath.Join(tmp, "config.d")
+	if err := os.MkdirAll(confd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	root := filepath.Join(tmp, "condor_config")
+	missing := filepath.Join(tmp, "absent.local") // never created -> must be tolerated
+	localFile := filepath.Join(tmp, "override.local")
+	rootBody := strings.Join([]string{
+		"LOCAL_DIR = /var",
+		"LOG = $(LOCAL_DIR)/log", // the default-shaped value config.d must override
+		`LOCAL_CONFIG_DIR_EXCLUDE_REGEXP = .*[.]py$`,
+		"LOCAL_CONFIG_DIR = " + confd,
+		"REQUIRE_LOCAL_CONFIG_FILE = false",
+		"LOCAL_CONFIG_FILE = " + missing + " " + localFile,
+		"",
+	}, "\n")
+	if err := os.WriteFile(root, []byte(rootBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// config.d: a real override plus a decoy script that must be excluded.
+	if err := os.WriteFile(filepath.Join(confd, "50-log.config"), []byte("LOG = /var/log/condor\nFROM_DIR = yes\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confd, "99-helper.py"), []byte("LOG = /EXCLUDED\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// LOCAL_CONFIG_FILE is processed after config.d, so it wins ties.
+	if err := os.WriteFile(localFile, []byte("FROM_FILE = yes\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CONDOR_CONFIG", root)
+	cfg, err := NewWithOptions(ConfigOptions{Subsystem: "COLLECTOR"})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+
+	for key, want := range map[string]string{
+		"LOG":       "/var/log/condor", // config.d override, NOT $(LOCAL_DIR)/log
+		"FROM_DIR":  "yes",             // config.d was processed
+		"FROM_FILE": "yes",             // LOCAL_CONFIG_FILE was processed (missing entry tolerated)
+	} {
+		if got, _ := cfg.Get(key); got != want {
+			t.Errorf("Get(%q) = %q, want %q", key, got, want)
+		}
+	}
+	if got, _ := cfg.Get("LOG"); got == "/EXCLUDED" {
+		t.Error("LOG picked up the excluded .py file; LOCAL_CONFIG_DIR_EXCLUDE_REGEXP not honored")
+	}
+	// A dependent expansion must see the overridden LOG (the reported symptom).
+	cfg.Set("ADDR", "$(LOG)/.collector_address")
+	if got, _ := cfg.Get("ADDR"); got != "/var/log/condor/.collector_address" {
+		t.Errorf("$(LOG) expansion = %q, want /var/log/condor/.collector_address", got)
+	}
+}
+
+// TestSubsystemLocalNameScoping verifies HTCondor's <SUBSYS>/<LOCALNAME> prefix
+// precedence in Get: <SUBSYS>.<LOCALNAME>.<KEY> beats <LOCALNAME>.<KEY> beats
+// <SUBSYS>.<KEY> beats the bare <KEY>. This is what lets an htc-collector view
+// host (-local-name HTCVIEW) take distinct values under one condor_master.
+func TestSubsystemLocalNameScoping(t *testing.T) {
+	body := strings.Join([]string{
+		"K = plain",
+		"COLLECTOR.K = subsys",
+		"HTCVIEW.K = local",
+		"COLLECTOR.HTCVIEW.K = both",
+		"ONLYLOCAL = plain2",
+		"HTCVIEW.ONLYLOCAL = local2",
+		"EMPTYABLE = someaddr",
+		"HTCVIEW.EMPTYABLE =",
+		"",
+	}, "\n")
+
+	cases := []struct {
+		subsys, local, key, want string
+	}{
+		{"COLLECTOR", "HTCVIEW", "K", "both"},           // most specific wins
+		{"COLLECTOR", "", "K", "subsys"},                // subsystem scope
+		{"", "HTCVIEW", "K", "local"},                   // local-name scope
+		{"", "", "K", "plain"},                          // bare
+		{"COLLECTOR", "HTCVIEW", "ONLYLOCAL", "local2"}, // falls through to local scope
+		{"COLLECTOR", "", "ONLYLOCAL", "plain2"},        // no subsys-scoped def -> bare
+		{"COLLECTOR", "HTCVIEW", "EMPTYABLE", ""},       // an empty scoped value suppresses the bare one
+		{"COLLECTOR", "", "EMPTYABLE", "someaddr"},      // other daemons still see the bare value
+	}
+	for _, tc := range cases {
+		cfg, err := NewFromReaderWithOptions(strings.NewReader(body),
+			ConfigOptions{Subsystem: tc.subsys, LocalName: tc.local, SkipDefaults: true})
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if got, _ := cfg.Get(tc.key); got != tc.want {
+			t.Errorf("subsys=%q local=%q Get(%q) = %q, want %q", tc.subsys, tc.local, tc.key, got, tc.want)
+		}
+	}
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -183,6 +183,16 @@ func (d *Daemon) Listener(fallback func() (net.Listener, error)) (net.Listener, 
 		d.mu.Unlock()
 		return spln, nil
 	}
+	// Non-shared-port under condor_master: adopt the command socket the master pre-created
+	// and inherited to us, rather than binding our own (which would EADDRINUSE against the
+	// master's already-bound port). See issue #119.
+	iln, err := resolveInheritedListener(d.log)
+	if err != nil {
+		return nil, err
+	}
+	if iln != nil {
+		return iln, nil
+	}
 	if fallback == nil {
 		return nil, fmt.Errorf("daemon: no shared-port listener inherited and no fallback provided")
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -186,11 +186,7 @@ func (d *Daemon) Listener(fallback func() (net.Listener, error)) (net.Listener, 
 	// Non-shared-port under condor_master: adopt the command socket the master pre-created
 	// and inherited to us, rather than binding our own (which would EADDRINUSE against the
 	// master's already-bound port). See issue #119.
-	iln, err := resolveInheritedListener(d.log)
-	if err != nil {
-		return nil, err
-	}
-	if iln != nil {
+	if iln := resolveInheritedListener(d.log); iln != nil {
 		return iln, nil
 	}
 	if fallback == nil {

--- a/daemon/inherit.go
+++ b/daemon/inherit.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -142,4 +143,69 @@ func extractSharedPortFromInherit(inherit string) (fd int, fullName string, ok b
 		return n, fullName, true
 	}
 	return 0, "", false
+}
+
+// resolveInheritedListener adopts the command-socket TCP listener that condor_master
+// pre-created and passed down through CONDOR_INHERIT's inherit-list, which is how a daemon
+// receives its command socket when USE_SHARED_PORT=False (there is no SharedPort: token
+// then). Returns (nil, nil) when no adoptable inherited stream socket is present, so the
+// caller falls back to a standalone bind. See issue #119.
+func resolveInheritedListener(logger *logging.Logger) (net.Listener, error) {
+	inherit := os.Getenv("CONDOR_INHERIT")
+	if inherit == "" {
+		return nil, nil
+	}
+	fd, ok := extractInheritedCommandSocket(inherit)
+	if !ok {
+		return nil, nil
+	}
+	f := os.NewFile(uintptr(fd), "inherited-command-socket")
+	if f == nil {
+		return nil, nil
+	}
+	ln, err := net.FileListener(f)
+	_ = f.Close() // net.FileListener dup'd the fd; release our reference to the original
+	if err != nil {
+		// The inherited fd was not a stream listener (e.g. only a UDP SafeSock was passed,
+		// or the fd is not adoptable): fall back to a standalone bind rather than fail.
+		logger.Warn(logging.DestinationGeneral,
+			"inherited command socket not adoptable; falling back to standalone bind",
+			"fd", fd, "error", err.Error())
+		return nil, nil
+	}
+	logger.Info(logging.DestinationGeneral,
+		"adopted inherited command socket from condor_master", "fd", fd, "addr", ln.Addr().String())
+	return ln, nil
+}
+
+// extractInheritedCommandSocket parses CONDOR_INHERIT's inherit-list -- the serialized
+// command sockets before the "0" sentinel -- and returns the fd of the FIRST one: the
+// ReliSock TCP command-port listener condor_master pre-created (it creates the stream
+// ReliSock before the optional UDP SafeSock, so the first entry is the listener to adopt).
+// Returns ok=false when the inherit-list is empty (the sentinel is first) or malformed.
+//
+// Format (daemon_core.cpp extractInheritedSocks):
+//
+//	<ppid> <psinful> <sock1> <sock2> ... 0 <remaining-items>...
+//
+// Each sockN is a serialized ReliSock/SafeSock, "<fd>*<state>*..." (the same encoding the
+// SharedPort: token carries after its endpoint name).
+func extractInheritedCommandSocket(inherit string) (fd int, ok bool) {
+	fields := strings.Fields(inherit)
+	if len(fields) < 3 {
+		return 0, false // need at least ppid, psinful, and a sock or the "0" sentinel
+	}
+	first := fields[2] // the first inherit-list entry, or the sentinel if none
+	if first == "0" {
+		return 0, false // no inherited sockets
+	}
+	fdStr := first
+	if i := strings.IndexByte(first, '*'); i >= 0 {
+		fdStr = first[:i]
+	}
+	n, err := strconv.Atoi(fdStr)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
 }

--- a/daemon/inherit.go
+++ b/daemon/inherit.go
@@ -83,6 +83,7 @@ func resolveSharedPortListener(logger *logging.Logger) (*sharedport.Listener, st
 	logf := func(format string, args ...any) {
 		logger.Warn(logging.DestinationGeneral, "shared-port event", "msg", fmt.Sprintf(format, args...))
 	}
+	//nolint:gosec // G115: fd is a small non-negative descriptor from the CONDOR_INHERIT SharedPort token
 	ln, err := sharedport.AdoptFD(uintptr(fd), sharedport.Options{
 		HandshakeTimeout: 10 * time.Second,
 		Logf:             logf,
@@ -150,18 +151,19 @@ func extractSharedPortFromInherit(inherit string) (fd int, fullName string, ok b
 // receives its command socket when USE_SHARED_PORT=False (there is no SharedPort: token
 // then). Returns (nil, nil) when no adoptable inherited stream socket is present, so the
 // caller falls back to a standalone bind. See issue #119.
-func resolveInheritedListener(logger *logging.Logger) (net.Listener, error) {
+func resolveInheritedListener(logger *logging.Logger) net.Listener {
 	inherit := os.Getenv("CONDOR_INHERIT")
 	if inherit == "" {
-		return nil, nil
+		return nil
 	}
 	fd, ok := extractInheritedCommandSocket(inherit)
 	if !ok {
-		return nil, nil
+		return nil
 	}
+	//nolint:gosec // G115: fd is a small non-negative descriptor from the CONDOR_INHERIT inherit-list
 	f := os.NewFile(uintptr(fd), "inherited-command-socket")
 	if f == nil {
-		return nil, nil
+		return nil
 	}
 	ln, err := net.FileListener(f)
 	_ = f.Close() // net.FileListener dup'd the fd; release our reference to the original
@@ -171,11 +173,11 @@ func resolveInheritedListener(logger *logging.Logger) (net.Listener, error) {
 		logger.Warn(logging.DestinationGeneral,
 			"inherited command socket not adoptable; falling back to standalone bind",
 			"fd", fd, "error", err.Error())
-		return nil, nil
+		return nil
 	}
 	logger.Info(logging.DestinationGeneral,
 		"adopted inherited command socket from condor_master", "fd", fd, "addr", ln.Addr().String())
-	return ln, nil
+	return ln
 }
 
 // extractInheritedCommandSocket parses CONDOR_INHERIT's inherit-list -- the serialized

--- a/daemon/inherit_test.go
+++ b/daemon/inherit_test.go
@@ -109,11 +109,11 @@ func TestExtractInheritedCommandSocket(t *testing.T) {
 // inherit-list and asserts resolveInheritedListener adopts it as a working listener that
 // accepts connections dialed to the original address.
 func TestResolveInheritedListener(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0") //nolint:noctx // test listener; context plumbing adds nothing here
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 	f, err := ln.(*net.TCPListener).File() // a dup fd standing in for the inherited one
 	if err != nil {
 		t.Fatal(err)
@@ -126,25 +126,22 @@ func TestResolveInheritedListener(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	adopted, err := resolveInheritedListener(logger)
-	if err != nil {
-		t.Fatal(err)
-	}
+	adopted := resolveInheritedListener(logger)
 	if adopted == nil {
 		t.Fatal("expected to adopt the inherited command socket")
 	}
-	defer adopted.Close()
+	defer func() { _ = adopted.Close() }()
 
 	accepted := make(chan net.Conn, 1)
 	go func() {
 		c, _ := adopted.Accept()
 		accepted <- c
 	}()
-	dc, err := net.Dial("tcp", ln.Addr().String())
+	dc, err := net.Dial("tcp", ln.Addr().String()) //nolint:noctx // test dial to a local listener
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer dc.Close()
+	defer func() { _ = dc.Close() }()
 	select {
 	case c := <-accepted:
 		if c == nil {

--- a/daemon/inherit_test.go
+++ b/daemon/inherit_test.go
@@ -1,6 +1,13 @@
 package daemon
 
-import "testing"
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bbockelm/golang-htcondor/logging"
+)
 
 // TestExtractSharedPortFromInherit covers the parser that pulls the SharedPort
 // fd + endpoint name out of CONDOR_INHERIT — the load-bearing step in the
@@ -64,6 +71,88 @@ func TestExtractSharedPortFromInherit(t *testing.T) {
 				t.Errorf("name = %q, want %q", name, tc.wantName)
 			}
 		})
+	}
+}
+
+// TestExtractInheritedCommandSocket covers the parser for the inherit-list command socket
+// condor_master passes when USE_SHARED_PORT=False (issue #119). The distinguishing signal
+// from shared-port mode: there the inherit-list is empty (the "0" sentinel is the first
+// entry) and the socket is a SharedPort: token instead.
+func TestExtractInheritedCommandSocket(t *testing.T) {
+	cases := []struct {
+		name    string
+		inherit string
+		wantFD  int
+		wantOK  bool
+	}{
+		{"non-shared-port TCP command socket", "123 <sinful> 14*5*0*0*0 0", 14, true},
+		{"TCP ReliSock then UDP SafeSock: adopt the first", "123 <sinful> 14*5*0 16*5*0 0", 14, true},
+		{"shared-port mode: inherit-list empty (sentinel first)", "29 <sinful> 0 SharedPort:cookie/name*15*6*0 0", 0, false},
+		{"no inherited sockets", "29 <sinful> 0 0", 0, false},
+		{"empty inherit string", "", 0, false},
+		{"malformed fd", "123 <sinful> notanum*5 0", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fd, ok := extractInheritedCommandSocket(tc.inherit)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (fd=%d)", ok, tc.wantOK, fd)
+			}
+			if tc.wantOK && fd != tc.wantFD {
+				t.Errorf("fd = %d, want %d", fd, tc.wantFD)
+			}
+		})
+	}
+}
+
+// TestResolveInheritedListener passes a real TCP listener's fd through a CONDOR_INHERIT
+// inherit-list and asserts resolveInheritedListener adopts it as a working listener that
+// accepts connections dialed to the original address.
+func TestResolveInheritedListener(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	f, err := ln.(*net.TCPListener).File() // a dup fd standing in for the inherited one
+	if err != nil {
+		t.Fatal(err)
+	}
+	// resolveInheritedListener takes ownership of the fd number and closes its reference,
+	// so we do not close f ourselves.
+	t.Setenv("CONDOR_INHERIT", fmt.Sprintf("123 <sinful> %d*5*0*0 0", f.Fd()))
+
+	logger, err := logging.New(&logging.Config{OutputPath: "stderr", SkipGlobalInstall: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	adopted, err := resolveInheritedListener(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adopted == nil {
+		t.Fatal("expected to adopt the inherited command socket")
+	}
+	defer adopted.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, _ := adopted.Accept()
+		accepted <- c
+	}()
+	dc, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dc.Close()
+	select {
+	case c := <-accepted:
+		if c == nil {
+			t.Fatal("adopted listener Accept returned nil")
+		}
+		_ = c.Close()
+	case <-time.After(3 * time.Second):
+		t.Fatal("adopted listener did not accept a connection to the inherited socket")
 	}
 }
 


### PR DESCRIPTION
Two fixes that let `htc-collector` (and any Go DaemonCore daemon) run correctly under `condor_master` on a real pool. Both were found while bringing up the golang-collector as a CONDOR_VIEW host alongside the stock C++ collector.

## 1. Read the local config chain + honor subsystem/local-name scoping (`config`)

**Config chain bug.** `LoadFromEnvironment` parsed only the root `CONDOR_CONFIG` file and never processed `LOCAL_CONFIG_DIR` (config.d) or `LOCAL_CONFIG_FILE` — the `processLocalConfigDir`/`processLocalConfigFile` helpers existed but were never called. On a production install where `LOG` (and most pool knobs) live in config.d, the Go config silently missed them and fell back to the param default, e.g. `LOG` resolved to `$(LOCAL_DIR)/log` instead of the config.d value — so `$(LOG)/…`-derived paths (address file, session DB) pointed at the wrong directory.

Now the chain is read in HTCondor's order — root → `LOCAL_CONFIG_DIR` (lexicographic) → `LOCAL_CONFIG_FILE` (later wins) — with `LOCAL_CONFIG_DIR_EXCLUDE_REGEXP` honored (so config.d `.py`/`.sh`/`.rpmnew` files are skipped) and a missing `LOCAL_CONFIG_FILE` tolerated unless `REQUIRE_LOCAL_CONFIG_FILE` is true.

**Subsystem/local-name scoping.** `Get` now applies HTCondor's prefix precedence — `<SUBSYS>.<LOCALNAME>.<KEY>` > `<LOCALNAME>.<KEY>` > `<SUBSYS>.<KEY>` > bare `<KEY>` — instead of a flat lookup. This is what lets two daemons of the same subsystem run under one `condor_master` with distinct config: an `htc-collector` view host started with `-local-name HTCVIEW` takes its own `HTCVIEW.COLLECTOR_LOG` / `HTCVIEW.COLLECTOR_ADDRESS_FILE` without colliding with the stock collector's.

Covered by a new end-to-end test (`config/local_chain_scoping_test.go`) exercising the real `LoadFromEnvironment` path — root + config.d + `LOCAL_CONFIG_FILE`, the exclude filter, missing-file tolerance, and the scoping precedence table. Verified against a real HTCondor install in a container (Go config now resolves the config.d `LOG` override, matching `condor_config_val`).

## 2. Adopt the inherited command socket when `USE_SHARED_PORT=False` (`daemon`, #119)

A Go DaemonCore daemon started by `condor_master` with `USE_SHARED_PORT=False` crash-looped with `bind: address already in use`: the master pre-binds the command socket and passes it via `CONDOR_INHERIT`, but the daemon only handled the shared-port token and fell back to binding its own port, colliding with the master's. It now adopts the inherited command socket from the `CONDOR_INHERIT` inherit-list. Fixes #119.

## Notes
- Both cherry-picked from the `schedd-ap-ecosystem` line; each touches a single package (`config`, `daemon`) and builds/tests clean on top of `main`.
- The same-master CONDOR_VIEW-host deployment was verified end-to-end with these changes (forwarding delivers; both the Go client and C++ `condor_status` query the co-located view daemon correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
