### PR TITLE
test: reap the condor daemon process group in the harness Shutdown (fix flaky TempDir cleanup)

### DIFF
--- a/testharness.go
+++ b/testharness.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/bbockelm/golang-htcondor/config"
@@ -240,6 +241,11 @@ ENABLE_WEB_SERVER = False
 		"_CONDOR_LOCAL_DIR="+h.tmpDir,
 	)
 	h.masterCmd.Dir = h.tmpDir
+	// Run the master as its own process-group leader so Shutdown can reap the whole
+	// daemon tree (condor_procd, schedd, shared_port, ...) as a group. Otherwise a
+	// child that outlives the master keeps writing under the t.TempDir spool/lock,
+	// and Go's TempDir RemoveAll fails with "directory not empty".
+	h.masterCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// Capture output for debugging
 	h.masterCmd.Stdout = os.Stdout
@@ -470,29 +476,52 @@ func (h *CondorTestHarness) checkStartdStatus() {
 
 // Shutdown stops the HTCondor instance
 func (h *CondorTestHarness) Shutdown() {
-	if h.masterCmd != nil && h.masterCmd.Process != nil {
-		h.t.Log("Shutting down HTCondor master")
+	if h.masterCmd == nil || h.masterCmd.Process == nil {
+		return
+	}
+	h.t.Log("Shutting down HTCondor master")
 
-		// Try graceful shutdown first
-		if err := h.masterCmd.Process.Signal(os.Interrupt); err != nil {
-			h.t.Logf("Failed to send interrupt to master: %v", err)
+	// Capture the process-group id before the process is reaped (Getpgid fails once
+	// it's gone); the master was started as a group leader, so pgid == the master pid.
+	pgid, pgidErr := syscall.Getpgid(h.masterCmd.Process.Pid)
+
+	// Try graceful shutdown first.
+	if err := h.masterCmd.Process.Signal(os.Interrupt); err != nil {
+		h.t.Logf("Failed to send interrupt to master: %v", err)
+	}
+
+	// Wait a bit for graceful shutdown.
+	done := make(chan error, 1)
+	go func() {
+		done <- h.masterCmd.Wait()
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		// Force kill if graceful shutdown times out.
+		if err := h.masterCmd.Process.Kill(); err != nil {
+			h.t.Logf("Failed to kill master: %v", err)
 		}
+		<-done // Wait for process to finish
+	case <-done:
+		// Graceful shutdown succeeded.
+	}
 
-		// Wait a bit for graceful shutdown
-		done := make(chan error, 1)
-		go func() {
-			done <- h.masterCmd.Wait()
-		}()
-
-		select {
-		case <-time.After(5 * time.Second):
-			// Force kill if graceful shutdown times out
-			if err := h.masterCmd.Process.Kill(); err != nil {
-				h.t.Logf("Failed to kill master: %v", err)
+	// Backstop: SIGKILL the whole process group so no orphaned child (condor_procd,
+	// schedd, shared_port) survives the master still holding open / writing files
+	// under the t.TempDir tree -- otherwise TempDir's RemoveAll races them and fails
+	// with "directory not empty". Harmless if the group is already gone (ESRCH).
+	if pgidErr == nil {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		// Wait for the group to drain so the kernel has released the children's file
+		// handles before the caller's TempDir RemoveAll runs. kill(-pgid, 0) returns
+		// ESRCH once no process in the group remains.
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if err := syscall.Kill(-pgid, 0); err != nil {
+				break // ESRCH: the process group is gone
 			}
-			<-done // Wait for process to finish
-		case <-done:
-			// Graceful shutdown succeeded
+			time.Sleep(20 * time.Millisecond)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

The integration test harness (`testharness.go`) starts `condor_master` and, on `Shutdown`, waited only for the **master** process. Its children — `condor_procd`, `schedd`, `condor_shared_port` — can outlive the master and keep writing under the test's `t.TempDir` `spool`/`lock`. Go's `t.TempDir` deferred `RemoveAll` then races them and fails the test with:

```
TempDir RemoveAll cleanup: unlinkat /tmp/.../spool: directory not empty
```

This flakes harness-based integration tests intermittently even when their own assertions pass — e.g. `TestScheddReleaseNonHeldReturnsBadStatusIntegration` (seen on golang-htcondor#120 CI; the test logged `Release of idle job correctly reported BadStatus=1` and then failed purely on the TempDir cleanup).

## Fix

- Start `condor_master` as its own **process-group leader** (`SysProcAttr{Setpgid: true}`).
- In `Shutdown`, after the existing graceful-shutdown / force-kill of the master, **`SIGKILL` the whole process group** as a backstop so no orphaned daemon survives holding files under `t.TempDir`.
- Briefly wait for the group to drain (`kill(-pgid, 0)` → ESRCH) so the kernel has released the children's file handles before the caller's `RemoveAll` runs.

The graceful-shutdown path is unchanged; the group kill only mops up stragglers (harmless if the group is already gone).

## Verification

Ran the previously-flaky `TestScheddReleaseNonHeldReturnsBadStatusIntegration` **6× clean** against a local HTCondor, with **no leftover `condor_*` processes** after the runs. `go build ./...`, gofmt, and golangci-lint on the changed file are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
