### PR TITLE
droppriv: parse CONDOR_IDS as uid.gid and never silently stay root

### DIFF
--- a/droppriv/condorids_regression_test.go
+++ b/droppriv/condorids_regression_test.go
@@ -1,0 +1,35 @@
+package droppriv
+
+import "testing"
+
+// TestParseIDPairDotFormat pins HTCondor's dot-separated CONDOR_IDS format
+// ("<uid>.<gid>"), the regression that let a misconfigured drop silently keep root.
+func TestParseIDPairDotFormat(t *testing.T) {
+	id, err := parseIDPair("999.987")
+	if err != nil {
+		t.Fatalf("dot format must parse: %v", err)
+	}
+	if id.UID != 999 || id.GID != 987 {
+		t.Fatalf("got %+v, want uid=999 gid=987", id)
+	}
+	// The old colon form is not HTCondor's format and must be rejected, not
+	// silently mis-parsed into a nil/zero identity.
+	if _, err := parseIDPair("999:987"); err == nil {
+		t.Fatal("colon format must be rejected")
+	}
+}
+
+// TestStartRefusesToStayRoot verifies the safety net: an enabled drop whose target
+// resolved to root must fail rather than "succeed" while still privileged.
+// (Only meaningful when the test itself runs as root; otherwise dropPrivileges to
+// a non-root target changes euid and the guard is not the code path under test.)
+func TestStartRefusesToStayRoot(t *testing.T) {
+	m := &Manager{enabled: true, defaultIdentity: Identity{UID: 0, GID: 0}}
+	err := m.Start()
+	// Running as root: the drop to uid0 is a no-op and the guard must fire.
+	// Running as non-root: dropPrivileges to uid0 fails first. Either way, Start
+	// must NOT return nil (which would mean "successfully running as root").
+	if err == nil {
+		t.Fatal("Start must never succeed while leaving the process as root")
+	}
+}

--- a/droppriv/manager.go
+++ b/droppriv/manager.go
@@ -151,6 +151,16 @@ func (m *Manager) Start() error {
 		return fmt.Errorf("failed to drop privileges: %w", err)
 	}
 
+	// Never silently remain root. If the drop target resolved to uid/gid 0 -- e.g. a
+	// misconfigured CONDOR_IDS or an unresolvable CONDOR_USER that fell back to the
+	// current (root) identity -- a "successful" drop leaves the process privileged.
+	// That is exactly the accident we must not have: refuse to continue as root.
+	if os.Geteuid() == 0 || os.Getegid() == 0 {
+		return fmt.Errorf("privilege drop left the process running as root (euid=%d egid=%d): "+
+			"refusing to run privileged; set CONDOR_IDS=<uid>.<gid> or CONDOR_USER to a non-root account",
+			os.Geteuid(), os.Getegid())
+	}
+
 	return nil
 }
 
@@ -237,9 +247,10 @@ func currentIdentity() (Identity, error) {
 }
 
 func parseIDPair(ids string) (Identity, error) {
-	parts := strings.Split(strings.TrimSpace(ids), ":")
+	// HTCondor's CONDOR_IDS is dot-separated "<uid>.<gid>" (e.g. "4.4"), not colon.
+	parts := strings.Split(strings.TrimSpace(ids), ".")
 	if len(parts) != 2 {
-		return Identity{}, fmt.Errorf("expected uid:gid format, got %q", ids)
+		return Identity{}, fmt.Errorf("expected uid.gid format, got %q", ids)
 	}
 	uid, err := parseUint32(strings.TrimSpace(parts[0]))
 	if err != nil {

--- a/droppriv/manager_test.go
+++ b/droppriv/manager_test.go
@@ -12,7 +12,7 @@ import (
 func TestConfigFromHTCondor(t *testing.T) {
 	cfg := config.NewEmpty()
 	cfg.Set("DROP_PRIVILEGES", "true")
-	cfg.Set("CONDOR_IDS", "42:84")
+	cfg.Set("CONDOR_IDS", "42.84") // HTCondor CONDOR_IDS is dot-separated "<uid>.<gid>"
 	cfg.Set("CONDOR_USER", "daemon")
 
 	conf := ConfigFromHTCondor(cfg)


### PR DESCRIPTION
## The bug (security)

A daemon started as **root** (as `condor_master` starts them) could **silently keep root privileges** when the drop target couldn't be resolved. htcondordb's `drop-privilege` CI test caught it: the child dropped to `euid=0 egid=0` instead of the target user.

Two failures compounded:

1. **`parseIDPair` split `CONDOR_IDS` on `:`**, but HTCondor's format is dot-separated `<uid>.<gid>` (e.g. `4.4`). A real `CONDOR_IDS=999.987` failed to parse — and `ConfigFromHTCondor` **swallowed the error**, leaving `CondorIDs = nil`.

2. With `CondorIDs` nil, `resolveDefaultIdentity` tried `lookupUser("condor")`; when that failed it fell back to **`currentIdentity()`** — which, running as root, is **uid 0**. The "drop" then targeted root and the daemon ran privileged **with no error**.

## Fix

- **`parseIDPair`** now splits on `.` (HTCondor's actual `CONDOR_IDS` format).
- **`Manager.Start()`** gains a hard safety net: after an enabled drop, if the process is still `uid`/`gid` 0, it returns an error instead of succeeding. **A drop that would leave us root is now fatal** — we never accidentally continue privileged. This guards *every* droppriv user (`daemon.New` and `htcondor-api`), not a single path.

## Tests

- `TestParseIDPairDotFormat` — pins the dot format, rejects the old colon form.
- `TestStartRefusesToStayRoot` — `Start()` never returns nil while leaving the process as root.
- Updated `TestConfigFromHTCondor` to the correct dot format.
- The end-to-end validation is htcondordb's root-only `TestDaemonDropsPrivilege` (runs as root in CI), which this fixes.

## Consumers

After tag, bump htcondordb to pick this up; its `drop-privilege` CI job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
