### PR TITLE
collector: map the Startd ad-type alias to the Machine TargetType

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -589,7 +589,7 @@ func createQueryAd(adType string, constraint *classad.Expr, projection []string,
 // getTargetTypeForAdType maps ad type to TargetType
 func getTargetTypeForAdType(adType string) string {
 	switch adType {
-	case "StartdAd", "Machine":
+	case "StartdAd", "Machine", "Startd":
 		return "Machine"
 	case "ScheddAd", "Schedd":
 		return "Scheduler"

--- a/collector_test.go
+++ b/collector_test.go
@@ -115,3 +115,26 @@ func TestGetCommandForAdType(t *testing.T) {
 		})
 	}
 }
+
+// TestAdTypeCommandTargetConsistency guards that every ad-type alias accepted by
+// getCommandForAdType resolves to the right TargetType. The "Startd" alias
+// regressed here: it produced QUERY_STARTD_ADS but a "Startd" TargetType (via the
+// default), so the collector returned per-startd daemon ads (MyType "StartD",
+// no per-slot Cpus/Memory/State) instead of the slot "Machine" ads matchmaking
+// needs.
+func TestAdTypeCommandTargetConsistency(t *testing.T) {
+	cases := []struct{ adType, wantTarget string }{
+		{"Startd", "Machine"},
+		{"StartdAd", "Machine"},
+		{"Machine", "Machine"},
+		{"Schedd", "Scheduler"},
+		{"Submitter", "Submitter"},
+		{"Collector", "Collector"},
+		{"Negotiator", "Negotiator"},
+	}
+	for _, tc := range cases {
+		if got := getTargetTypeForAdType(tc.adType); got != tc.wantTarget {
+			t.Errorf("getTargetTypeForAdType(%q) = %q, want %q", tc.adType, got, tc.wantTarget)
+		}
+	}
+}


### PR DESCRIPTION
`getCommandForAdType` accepts `Startd`/`StartdAd`/`Machine` for
`QUERY_STARTD_ADS`, but `getTargetTypeForAdType` only handled
`StartdAd`/`Machine` — so `QueryAds("Startd", ...)` fell through to the default
and sent `TargetType="Startd"`. The collector then returned per-startd daemon
rollup ads (MyType `StartD`, `TotalSlots`, only `Total*`/`Detected*` resources)
instead of the per-slot Machine ads, which lack the `Cpus`/`Memory`/`Disk`/`State`
attributes matchmaking compares against — so every match silently failed.

Adds `Startd` to the Machine case and a consistency test.

Recent local commit that hadn't been pushed yet; opening as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
