### PR TITLE
collector: give LocateDaemon a typed DaemonType and translate to the ad type

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -188,7 +188,8 @@ func (c *Collector) notePreferred(addr string) {
 }
 
 // QueryAds queries the collector for daemon advertisements
-// adType specifies the type of ads to query (e.g., "StartdAd", "ScheddAd")
+// adType selects the ad type to query — one of the *AdType constants (e.g.
+// ScheddAdType), or a daemon-type name like "Schedd"
 // constraint is a ClassAd constraint expression string (pass empty string for no constraint)
 //
 // Deprecated: Use QueryAdsWithOptions for pagination and default limits/projections
@@ -197,7 +198,8 @@ func (c *Collector) QueryAds(ctx context.Context, adType string, constraint stri
 }
 
 // QueryAdsWithProjection queries the collector for daemon advertisements with optional projection
-// adType specifies the type of ads to query (e.g., "StartdAd", "ScheddAd")
+// adType selects the ad type to query — one of the *AdType constants (e.g.
+// ScheddAdType), or a daemon-type name like "Schedd"
 // constraint is a ClassAd constraint expression string (pass empty string for no constraint)
 // projection is an optional list of attribute names to return (pass nil for all attributes)
 //
@@ -971,21 +973,39 @@ const (
 	DaemonNegotiator DaemonType = "Negotiator"
 )
 
+// Ad type names accepted as the adType argument by the collector query methods
+// (QueryAds, QueryAdsWithProjection, QueryAdsWithOptions, QueryAdsStream). Each
+// names the ad a daemon advertises — a schedd advertises a ScheddAd, whose MyType
+// is "Scheduler" — and selects the matching collector query. The daemon-type
+// spellings (e.g. "Schedd") are also accepted, but prefer these constants.
+//
+// They are plain string constants so they drop into the existing adType string
+// parameters without a conversion.
+const (
+	StartdAdType     = "StartdAd"
+	ScheddAdType     = "ScheddAd"
+	MasterAdType     = "MasterAd"
+	SubmitterAdType  = "SubmitterAd"
+	LicenseAdType    = "LicenseAd"
+	CollectorAdType  = "CollectorAd"
+	NegotiatorAdType = "NegotiatorAd"
+)
+
 // adType returns the collector-query ad type corresponding to the daemon type
-// (e.g. DaemonSchedd -> "ScheddAd"). An unknown/custom type is passed through
+// (e.g. DaemonSchedd -> ScheddAdType). An unknown/custom type is passed through
 // unchanged, for which the query maps fall back to QUERY_GENERIC_ADS.
 func (dt DaemonType) adType() string {
 	switch dt {
 	case DaemonSchedd:
-		return "ScheddAd"
+		return ScheddAdType
 	case DaemonStartd:
-		return "StartdAd"
+		return StartdAdType
 	case DaemonMaster:
-		return "MasterAd"
+		return MasterAdType
 	case DaemonCollector:
-		return "CollectorAd"
+		return CollectorAdType
 	case DaemonNegotiator:
-		return "NegotiatorAd"
+		return NegotiatorAdType
 	default:
 		return string(dt)
 	}

--- a/collector.go
+++ b/collector.go
@@ -965,6 +965,7 @@ func estimateClassAdSize(ad *classad.ClassAd) int {
 // "ScheddAd" ad type. LocateDaemon does that translation for you (see adType).
 type DaemonType string
 
+// Daemon types accepted by LocateDaemon.
 const (
 	DaemonSchedd     DaemonType = "Schedd"
 	DaemonStartd     DaemonType = "Startd"

--- a/collector.go
+++ b/collector.go
@@ -955,10 +955,52 @@ func estimateClassAdSize(ad *classad.ClassAd) int {
 	return len(attrs) * AvgBytesPerAttribute
 }
 
-// LocateDaemon locates a daemon by querying the collector
-// daemonType specifies the type of daemon to locate (e.g., "Schedd", "Startd", "Master")
-// name is the name of the daemon to locate (optional, pass empty string to find any)
-func (c *Collector) LocateDaemon(ctx context.Context, daemonType string, name string) (*DaemonLocation, error) {
+// DaemonType identifies a kind of HTCondor daemon for LocateDaemon. It mirrors
+// the daemon types used by the HTCondor Python bindings' Collector.locate().
+//
+// A daemon type is distinct from the collector-query ad type: a schedd, for
+// example, is DaemonSchedd but advertises a "Scheduler" ad queried as the
+// "ScheddAd" ad type. LocateDaemon does that translation for you (see adType).
+type DaemonType string
+
+const (
+	DaemonSchedd     DaemonType = "Schedd"
+	DaemonStartd     DaemonType = "Startd"
+	DaemonMaster     DaemonType = "Master"
+	DaemonCollector  DaemonType = "Collector"
+	DaemonNegotiator DaemonType = "Negotiator"
+)
+
+// adType returns the collector-query ad type corresponding to the daemon type
+// (e.g. DaemonSchedd -> "ScheddAd"). An unknown/custom type is passed through
+// unchanged, for which the query maps fall back to QUERY_GENERIC_ADS.
+func (dt DaemonType) adType() string {
+	switch dt {
+	case DaemonSchedd:
+		return "ScheddAd"
+	case DaemonStartd:
+		return "StartdAd"
+	case DaemonMaster:
+		return "MasterAd"
+	case DaemonCollector:
+		return "CollectorAd"
+	case DaemonNegotiator:
+		return "NegotiatorAd"
+	default:
+		return string(dt)
+	}
+}
+
+// LocateDaemon locates a daemon by querying the collector.
+//
+// daemonType is the kind of daemon to locate — one of the DaemonType constants
+// (DaemonSchedd, DaemonStartd, DaemonMaster, DaemonCollector, DaemonNegotiator).
+// It is translated to the corresponding collector-query ad type internally, so
+// callers pass a daemon type (DaemonSchedd), not an ad type ("ScheddAd").
+//
+// name is the name of the daemon to locate (optional, pass empty string to find
+// any).
+func (c *Collector) LocateDaemon(ctx context.Context, daemonType DaemonType, name string) (*DaemonLocation, error) {
 	// Construct constraint to match the daemon name if provided
 	constraint := ""
 	if name != "" {
@@ -972,7 +1014,7 @@ func (c *Collector) LocateDaemon(ctx context.Context, daemonType string, name st
 		Projection: projection,
 	}
 
-	ads, _, err := c.QueryAdsWithOptions(ctx, daemonType, constraint, opts)
+	ads, _, err := c.QueryAdsWithOptions(ctx, daemonType.adType(), constraint, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query collector for %s daemon: %w", daemonType, err)
 	}

--- a/collector_test.go
+++ b/collector_test.go
@@ -57,9 +57,46 @@ func TestCollectorLocateDaemon(t *testing.T) {
 	collector := NewCollector("collector.example.com:9618")
 	ctx := context.Background()
 
-	_, err := collector.LocateDaemon(ctx, "Schedd", "test_schedd")
+	_, err := collector.LocateDaemon(ctx, DaemonSchedd, "test_schedd")
 	if err == nil {
 		t.Error("Expected error when connecting to non-existent collector")
+	}
+}
+
+// TestDaemonTypeAdType verifies each DaemonType translates to the collector-query
+// ad type LocateDaemon passes on, and that the resulting ad type resolves to the
+// correct query command and TargetType (i.e. locating a daemon type queries for
+// the right ad, not the daemon-type string used verbatim).
+func TestDaemonTypeAdType(t *testing.T) {
+	tests := []struct {
+		dt         DaemonType
+		wantAdType string
+		wantCmd    commands.CommandType
+		wantTarget string
+	}{
+		{DaemonSchedd, "ScheddAd", commands.QUERY_SCHEDD_ADS, "Scheduler"},
+		{DaemonStartd, "StartdAd", commands.QUERY_STARTD_ADS, "Machine"},
+		{DaemonMaster, "MasterAd", commands.QUERY_MASTER_ADS, "DaemonMaster"},
+		{DaemonCollector, "CollectorAd", commands.QUERY_COLLECTOR_ADS, "Collector"},
+		{DaemonNegotiator, "NegotiatorAd", commands.QUERY_NEGOTIATOR_ADS, "Negotiator"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.dt), func(t *testing.T) {
+			adType := tt.dt.adType()
+			if adType != tt.wantAdType {
+				t.Errorf("%s.adType() = %q, want %q", tt.dt, adType, tt.wantAdType)
+			}
+			if cmd := getCommandForAdType(adType); cmd != tt.wantCmd {
+				t.Errorf("getCommandForAdType(%q) = %v, want %v", adType, cmd, tt.wantCmd)
+			}
+			if tgt := getTargetTypeForAdType(adType); tgt != tt.wantTarget {
+				t.Errorf("getTargetTypeForAdType(%q) = %q, want %q", adType, tgt, tt.wantTarget)
+			}
+		})
+	}
+	// An unknown/custom daemon type passes through unchanged.
+	if got := DaemonType("Custom").adType(); got != "Custom" {
+		t.Errorf("DaemonType(\"Custom\").adType() = %q, want %q", got, "Custom")
 	}
 }
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -57,7 +57,7 @@ fmt.Printf("auth=%s user=%s encrypted=%v\n",
     ping.AuthMethod, ping.User, ping.Encryption)
 
 // Locate a specific daemon by type + name.
-where, err := collector.LocateDaemon(ctx, "Schedd", "myschedd")
+where, err := collector.LocateDaemon(ctx, htcondor.DaemonSchedd, "myschedd")
 if err != nil {
     log.Fatal(err)
 }

--- a/docs/library.md
+++ b/docs/library.md
@@ -38,7 +38,7 @@ ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 defer cancel()
 
 // Query advertisements with pagination / projection.
-ads, page, err := collector.QueryAdsWithOptions(ctx, "ScheddAd", "",
+ads, page, err := collector.QueryAdsWithOptions(ctx, htcondor.ScheddAdType, "",
     &htcondor.QueryOptions{
         Limit:      50,
         Projection: []string{"Name", "Machine", "Cpus", "Memory"},


### PR DESCRIPTION
## `collector: give LocateDaemon a typed DaemonType and translate to the ad type`

Relates to #111.

### The problem
`LocateDaemon` took a stringly-typed `daemonType` (documented with examples like
`"Schedd"`) and passed it **straight** to `QueryAdsWithOptions` as the `adType`.
That only worked because `getCommandForAdType`/`getTargetTypeForAdType` leniently
accept *both* the daemon-type form (`"Schedd"`) and the ad-type form
(`"ScheddAd"`) — so there was no runtime bug, but the relationship was accidental
and the docs were inconsistent (`LocateDaemon` said `Schedd`, `QueryAds` said
`ScheddAd`).

### The fix (the typed direction the issue leaned toward)
- Add a `DaemonType` type with constants — `DaemonSchedd`, `DaemonStartd`,
  `DaemonMaster`, `DaemonCollector`, `DaemonNegotiator` — mirroring the HTCondor
  Python bindings' daemon types.
- `LocateDaemon` now takes a `DaemonType` and **explicitly translates** it to the
  corresponding collector-query ad type (`DaemonSchedd` → `"ScheddAd"`) via
  `DaemonType.adType()` before querying. A daemon type is never used verbatim as
  an ad type again.
- Docs on `LocateDaemon` updated to name the constants and the distinction.

### Compatibility
Non-breaking: the constants are string-based, so existing literal callers
(`LocateDaemon(ctx, "Schedd", …)`) still compile unchanged.

### Tests
Adds `TestDaemonTypeAdType`, asserting each `DaemonType` resolves to the correct
ad type, query command, and `TargetType`. Verified locally: build (all three
modules), `go vet`, `gofmt`, and tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
