### PR TITLE
test: harden condor harness teardown against the log-dir removal race

### DIFF
--- a/testharness.go
+++ b/testharness.go
@@ -108,8 +108,29 @@ func SetupCondorHarnessWithConfig(t TestingT, extraConfig string) *CondorTestHar
 		}
 	}
 
-	// Create temporary directory structure
-	tmpDir := t.TempDir()
+	// Create a harness-owned temporary directory (deliberately NOT t.TempDir).
+	// An HTCondor daemon occasionally outlives Shutdown's process-group backstop
+	// for a moment (e.g. one that setsid'd out of the group, or is slow to die)
+	// and writes under log/ just as teardown removes the tree. t.TempDir would
+	// surface that race as a t.Errorf ("directory not empty") and fail the test;
+	// owning the removal lets us retry past the straggler instead.
+	tmpDir, err := os.MkdirTemp("", "condor-harness-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		// Register before Shutdown's cleanup so this runs after it (LIFO).
+		var rmErr error
+		for i := 0; i < 50; i++ {
+			if rmErr = os.RemoveAll(tmpDir); rmErr == nil {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		// Best effort: a leftover temp dir the OS will reclaim is not a test
+		// failure — unlike a spurious teardown error would be.
+		t.Logf("temp dir cleanup gave up: %v (leaving %s)", rmErr, tmpDir)
+	})
 
 	h := &CondorTestHarness{
 		tmpDir:     tmpDir,


### PR DESCRIPTION
## Harden the condor test-harness teardown against a log-dir removal race

`TestGoDaemonUnderCondorMaster` (and potentially any integration test using
`CondorTestHarness`) can flake with:

```
testing.go: TempDir RemoveAll cleanup: unlinkat .../log: directory not empty
```

### Cause
The harness put the HTCondor log/spool/lock tree under `t.TempDir()`. `Shutdown()`
has a process-group `SIGKILL` + drain backstop, but a daemon occasionally outlives
it for a moment — one that `setsid`'d out of the group, or is just slow to die —
and writes a log file *while* teardown is removing the tree. Because it was a
`t.TempDir()`, Go's own `RemoveAll` reports the race via `t.Errorf`, failing the
test. (This flaked #132's Docker test jobs, though it's unrelated to that PR.)

### Fix
Own the temp dir (`os.MkdirTemp`) and remove it in a `t.Cleanup` that **retries**
`RemoveAll` (~5s) to ride out the straggler, then `t.Logf`s — not `t.Errorf`s — if
it still can't. A leftover temp dir the OS reclaims is not a test failure, unlike a
spurious teardown error. Registered before `Shutdown`'s cleanup so it still runs
after it (LIFO), preserving the "shut daemons down, then remove" order.

Compiles under `-tags=integration`. This is shared-harness robustness — benefits
every integration test, not just #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
