### PR TITLE
Production hardening: security defaults, log routing/reconfig/mode, subsystem resolution

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,6 +108,11 @@ func NewEmpty() *Config {
 }
 
 // NewWithOptions creates a new Config with specified options
+// Options returns the options this Config was constructed with. It lets a caller reload
+// (e.g. on condor_reconfig) while preserving subsystem and local-name prefix resolution —
+// a bare config.New() reload would drop them and stop resolving <SUBSYS>.PARAM overrides.
+func (c *Config) Options() ConfigOptions { return c.options }
+
 func NewWithOptions(opts ConfigOptions) (*Config, error) {
 	cfg := &Config{
 		values:        make(map[string]string),

--- a/config/config.go
+++ b/config/config.go
@@ -107,12 +107,12 @@ func NewEmpty() *Config {
 	return cfg
 }
 
-// NewWithOptions creates a new Config with specified options
 // Options returns the options this Config was constructed with. It lets a caller reload
 // (e.g. on condor_reconfig) while preserving subsystem and local-name prefix resolution —
 // a bare config.New() reload would drop them and stop resolving <SUBSYS>.PARAM overrides.
 func (c *Config) Options() ConfigOptions { return c.options }
 
+// NewWithOptions creates a new Config with specified options.
 func NewWithOptions(opts ConfigOptions) (*Config, error) {
 	cfg := &Config{
 		values:        make(map[string]string),

--- a/config/param_overrides.go
+++ b/config/param_overrides.go
@@ -20,24 +20,6 @@ var paramOverrides = []struct {
 	Default string
 }{
 	{
-		// Generated default in param_defaults.go is the very old
-		// "FS,TOKEN" pair, dating from before HTCondor split TOKEN
-		// into IDTOKENS/SCITOKENS and added SSL to its built-in
-		// fallback. Modern HTCondor (verified against 25.8 via
-		// `condor_config_val -v SEC_DEFAULT_AUTHENTICATION_METHODS`)
-		// uses the broader list below as its `<Default>` source.
-		//
-		// The stale value caused a real production failure: a
-		// match-analysis collector query offered TOKEN only, the
-		// server's IDTOKENS were filtered by iss/kid mismatch, and
-		// the handshake errored out with "no compatible authentication
-		// methods found" even though SSL would have worked on both
-		// sides. Aligning with HTCondor's real default lets cedar
-		// negotiate SSL transparently when token auth fails.
-		Name:    "SEC_DEFAULT_AUTHENTICATION_METHODS",
-		Default: "FS,IDTOKENS,KERBEROS,SCITOKENS,SSL",
-	},
-	{
 		// Encryption method default. In param_info.in this only appears
 		// inside the security:* metaknobs (recommended/strong/FIPS),
 		// never as a standalone param, so nothing bootstraps it unless a
@@ -49,26 +31,18 @@ var paramOverrides = []struct {
 		// AES matches HTCondor 9.0+ (<Default> = AES); cedar only
 		// implements AES-GCM anyway. The CLIENT/READ/etc. contexts fall
 		// through to this via getSecurityMethods.
+		//
+		// Note: the authentication-method defaults are NOT bootstrapped
+		// here. They are built programmatically in getSecurityMethods /
+		// getDefaultAuthMethods (security.go) from the methods cedar
+		// actually implements — the Go analogue of C++ building
+		// SEC_STD_AUTH_METHOD_NAMES from compile-time HAVE_EXT_* flags —
+		// so a static override cannot list a method (e.g. KERBEROS) that
+		// cedar cannot perform. The stale generated
+		// SEC_DEFAULT_AUTHENTICATION_METHODS = "FS,TOKEN" is handled
+		// there (isStaleAuthDefault), not overridden here.
 		Name:    "SEC_DEFAULT_CRYPTO_METHODS",
 		Default: "AES",
-	},
-	{
-		// Client context inherits the default crypto methods, matching
-		// param_info.in's SEC_CLIENT_CRYPTO_METHODS = $(SEC_DEFAULT_CRYPTO_METHODS).
-		Name:    "SEC_CLIENT_CRYPTO_METHODS",
-		Default: "$(SEC_DEFAULT_CRYPTO_METHODS)",
-	},
-	{
-		// Client auth methods = the default set plus ANONYMOUS, matching
-		// param_info.in (SEC_CLIENT_AUTHENTICATION_METHODS =
-		// $(SEC_DEFAULT_AUTHENTICATION_METHODS), ANONYMOUS). The trailing
-		// ANONYMOUS is what lets a client do an encrypted-but-
-		// unauthenticated READ (e.g. a collector query) when no stronger
-		// method succeeds. Operators can still override per subsystem
-		// (e.g. TOOL.SEC_CLIENT_AUTHENTICATION_METHODS); that resolves
-		// only when the caller sets its config Subsystem.
-		Name:    "SEC_CLIENT_AUTHENTICATION_METHODS",
-		Default: "$(SEC_DEFAULT_AUTHENTICATION_METHODS), ANONYMOUS",
 	},
 	{
 		// HTTP_API_LOG follows HTCondor's per-daemon log convention:

--- a/config/param_overrides.go
+++ b/config/param_overrides.go
@@ -38,6 +38,39 @@ var paramOverrides = []struct {
 		Default: "FS,IDTOKENS,KERBEROS,SCITOKENS,SSL",
 	},
 	{
+		// Encryption method default. In param_info.in this only appears
+		// inside the security:* metaknobs (recommended/strong/FIPS),
+		// never as a standalone param, so nothing bootstraps it unless a
+		// config does `use security:...`. Without it, cfg.Get(
+		// "SEC_DEFAULT_CRYPTO_METHODS") returns false and encryption
+		// negotiation survived only on a scattered "AES" string literal
+		// deep in getSecurityMethods — a workaround, not a real default,
+		// and invisible to condor_config_val or any direct cfg.Get.
+		// AES matches HTCondor 9.0+ (<Default> = AES); cedar only
+		// implements AES-GCM anyway. The CLIENT/READ/etc. contexts fall
+		// through to this via getSecurityMethods.
+		Name:    "SEC_DEFAULT_CRYPTO_METHODS",
+		Default: "AES",
+	},
+	{
+		// Client context inherits the default crypto methods, matching
+		// param_info.in's SEC_CLIENT_CRYPTO_METHODS = $(SEC_DEFAULT_CRYPTO_METHODS).
+		Name:    "SEC_CLIENT_CRYPTO_METHODS",
+		Default: "$(SEC_DEFAULT_CRYPTO_METHODS)",
+	},
+	{
+		// Client auth methods = the default set plus ANONYMOUS, matching
+		// param_info.in (SEC_CLIENT_AUTHENTICATION_METHODS =
+		// $(SEC_DEFAULT_AUTHENTICATION_METHODS), ANONYMOUS). The trailing
+		// ANONYMOUS is what lets a client do an encrypted-but-
+		// unauthenticated READ (e.g. a collector query) when no stronger
+		// method succeeds. Operators can still override per subsystem
+		// (e.g. TOOL.SEC_CLIENT_AUTHENTICATION_METHODS); that resolves
+		// only when the caller sets its config Subsystem.
+		Name:    "SEC_CLIENT_AUTHENTICATION_METHODS",
+		Default: "$(SEC_DEFAULT_AUTHENTICATION_METHODS), ANONYMOUS",
+	},
+	{
 		// HTTP_API_LOG follows HTCondor's per-daemon log convention:
 		// every DC daemon's log path defaults to $(LOG)/<CamelCase>Log
 		// (see param_info.in's MASTER_LOG, NEGOTIATOR_LOG, etc.).

--- a/config/security_defaults_test.go
+++ b/config/security_defaults_test.go
@@ -5,38 +5,18 @@ import (
 	"testing"
 )
 
-// TestSecurityMethodDefaults verifies the bootstrapped security defaults resolve even with
-// no operator config (the "missing bootstrapping" fix): these params live only inside
-// param_info.in metaknobs upstream, so without an override cfg.Get returns false and
-// encryption/auth negotiation has no configured basis.
-func TestSecurityMethodDefaults(t *testing.T) {
+// TestCryptoMethodDefault verifies the bootstrapped crypto default resolves with no operator
+// config. (The authentication-method defaults are built programmatically in the security
+// layer from cedar's implemented methods, not bootstrapped here — see the htcondor package's
+// security tests.)
+func TestCryptoMethodDefault(t *testing.T) {
 	cfg, err := NewFromReader(strings.NewReader(""))
 	if err != nil {
 		t.Fatal(err)
 	}
-	cases := []struct {
-		key       string
-		want      string
-		substring bool
-	}{
-		{"SEC_DEFAULT_CRYPTO_METHODS", "AES", false},
-		{"SEC_CLIENT_CRYPTO_METHODS", "AES", false},              // $(SEC_DEFAULT_CRYPTO_METHODS)
-		{"SEC_CLIENT_AUTHENTICATION_METHODS", "ANONYMOUS", true}, // ...,ANONYMOUS for encrypted READ
-		{"SEC_DEFAULT_AUTHENTICATION_METHODS", "IDTOKENS", true}, // pre-existing override
-	}
-	for _, c := range cases {
-		got, ok := cfg.Get(c.key)
-		if !ok {
-			t.Errorf("%s: not set (bootstrap default missing)", c.key)
-			continue
-		}
-		if c.substring {
-			if !strings.Contains(got, c.want) {
-				t.Errorf("%s = %q, want it to contain %q", c.key, got, c.want)
-			}
-		} else if strings.TrimSpace(got) != c.want {
-			t.Errorf("%s = %q, want %q", c.key, got, c.want)
-		}
+	got, ok := cfg.Get("SEC_DEFAULT_CRYPTO_METHODS")
+	if !ok || strings.TrimSpace(got) != "AES" {
+		t.Errorf("SEC_DEFAULT_CRYPTO_METHODS = %q (ok=%v), want AES", got, ok)
 	}
 }
 

--- a/config/security_defaults_test.go
+++ b/config/security_defaults_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSecurityMethodDefaults verifies the bootstrapped security defaults resolve even with
+// no operator config (the "missing bootstrapping" fix): these params live only inside
+// param_info.in metaknobs upstream, so without an override cfg.Get returns false and
+// encryption/auth negotiation has no configured basis.
+func TestSecurityMethodDefaults(t *testing.T) {
+	cfg, err := NewFromReader(strings.NewReader(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		key       string
+		want      string
+		substring bool
+	}{
+		{"SEC_DEFAULT_CRYPTO_METHODS", "AES", false},
+		{"SEC_CLIENT_CRYPTO_METHODS", "AES", false},              // $(SEC_DEFAULT_CRYPTO_METHODS)
+		{"SEC_CLIENT_AUTHENTICATION_METHODS", "ANONYMOUS", true}, // ...,ANONYMOUS for encrypted READ
+		{"SEC_DEFAULT_AUTHENTICATION_METHODS", "IDTOKENS", true}, // pre-existing override
+	}
+	for _, c := range cases {
+		got, ok := cfg.Get(c.key)
+		if !ok {
+			t.Errorf("%s: not set (bootstrap default missing)", c.key)
+			continue
+		}
+		if c.substring {
+			if !strings.Contains(got, c.want) {
+				t.Errorf("%s = %q, want it to contain %q", c.key, got, c.want)
+			}
+		} else if strings.TrimSpace(got) != c.want {
+			t.Errorf("%s = %q, want %q", c.key, got, c.want)
+		}
+	}
+}
+
+// TestSubsystemPrefixResolution is the regression for the client Subsystem bug: an operator
+// value scoped TOOL.<param> resolves only when the config was built with Subsystem "TOOL"
+// (as the htcondordb-cli/capi clients now do); an empty subsystem silently ignores it.
+func TestSubsystemPrefixResolution(t *testing.T) {
+	const text = "TOOL.SEC_CLIENT_AUTHENTICATION_METHODS = FS SSL PASSWORD\n"
+
+	withTool, err := NewFromReaderWithOptions(strings.NewReader(text), ConfigOptions{Subsystem: "TOOL"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := withTool.Get("SEC_CLIENT_AUTHENTICATION_METHODS"); !ok || got != "FS SSL PASSWORD" {
+		t.Errorf("with Subsystem=TOOL: got %q (ok=%v), want operator value 'FS SSL PASSWORD'", got, ok)
+	}
+
+	// Empty subsystem: the TOOL.-scoped value is invisible, so it falls back to the default.
+	noSub, err := NewFromReader(strings.NewReader(text))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := noSub.Get("SEC_CLIENT_AUTHENTICATION_METHODS"); got == "FS SSL PASSWORD" {
+		t.Errorf("empty subsystem should NOT resolve the TOOL.-scoped override, but got %q", got)
+	}
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -415,12 +415,18 @@ func (d *Daemon) waitServe(serveErr <-chan error, n int) {
 // reconfigure reloads config from CONDOR_CONFIG and runs OnReconfig callbacks.
 func (d *Daemon) reconfigure() {
 	d.log.Info(logging.DestinationGeneral, "received SIGHUP; reloading configuration")
-	cfg, err := config.New()
+	// Reload preserving the original options (subsystem/local name) so <SUBSYS>.PARAM
+	// overrides still resolve after a reconfig; a bare config.New() would drop them.
+	cfg, err := config.NewWithOptions(d.cfg.Load().Options())
 	if err != nil {
 		d.log.Warn(logging.DestinationGeneral, "reconfigure: reloading config failed; keeping current", "error", err)
 		return
 	}
 	d.cfg.Store(cfg)
+	// Re-apply per-destination log levels from the reloaded config, so condor_reconfig
+	// changes log verbosity on the running daemon (the levels are held in a live atomic
+	// snapshot the installed handlers read).
+	d.log.ApplyLevels(logging.ParseDestinationLevels(d.subsys, cfg), logging.DefaultDaemonLevel)
 	d.mu.Lock()
 	cbs := append([]func(*config.Config){}, d.onReconfig...)
 	d.mu.Unlock()

--- a/daemon/slog.go
+++ b/daemon/slog.go
@@ -39,17 +39,50 @@ func (h *slogBridge) Handle(_ context.Context, r slog.Record) error {
 		return true
 	})
 
+	// Honor the destination the record names (e.g. cedar tags its records
+	// destination=cedar) instead of forcing General, and drop that attribute so
+	// logging.Logger re-adds exactly one canonical destination rather than leaving the
+	// record with two (the bug that produced "destination=general destination=cedar" and
+	// bypassed the cedar destination's Warn-level suppression). Absent/unknown -> General.
+	dest, args := extractDestination(args)
+
 	switch {
 	case r.Level >= slog.LevelError:
-		h.log.Error(logging.DestinationGeneral, r.Message, args...)
+		h.log.Error(dest, r.Message, args...)
 	case r.Level >= slog.LevelWarn:
-		h.log.Warn(logging.DestinationGeneral, r.Message, args...)
+		h.log.Warn(dest, r.Message, args...)
 	case r.Level >= slog.LevelInfo:
-		h.log.Info(logging.DestinationGeneral, r.Message, args...)
+		h.log.Info(dest, r.Message, args...)
 	default:
-		h.log.Debug(logging.DestinationGeneral, r.Message, args...)
+		h.log.Debug(dest, r.Message, args...)
 	}
 	return nil
+}
+
+// extractDestination pulls a "destination" key/value pair out of a flat key,value arg
+// slice and maps it to a logging.Destination, returning the remaining args with that pair
+// removed. slog callers such as cedar tag records with destination="cedar"; the bridge
+// routes on that and removes it so logging.Logger stamps exactly one canonical destination.
+// Defaults to DestinationGeneral when the attribute is absent or unrecognized.
+func extractDestination(args []any) (logging.Destination, []any) {
+	dest := logging.DestinationGeneral
+	filtered := args[:0]
+	for i := 0; i < len(args); i += 2 {
+		if i+1 >= len(args) {
+			filtered = append(filtered, args[i]) // dangling key; preserve
+			break
+		}
+		if k, ok := args[i].(string); ok && k == "destination" {
+			if s, ok := args[i+1].(string); ok {
+				if d, ok := logging.ParseDestination(s); ok {
+					dest = d
+				}
+			}
+			continue // drop the destination pair
+		}
+		filtered = append(filtered, args[i], args[i+1])
+	}
+	return dest, filtered
 }
 
 func (h *slogBridge) WithAttrs(attrs []slog.Attr) slog.Handler {

--- a/daemon/slog_test.go
+++ b/daemon/slog_test.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bbockelm/golang-htcondor/logging"
+)
+
+func TestExtractDestination(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []any
+		wantDest logging.Destination
+		wantArgs []any
+	}{
+		{"absent", []any{"k", "v"}, logging.DestinationGeneral, []any{"k", "v"}},
+		{"cedar", []any{"destination", "cedar", "k", "v"}, logging.DestinationCedar, []any{"k", "v"}},
+		{"cedar-middle", []any{"a", 1, "destination", "cedar"}, logging.DestinationCedar, []any{"a", 1}},
+		{"unknown-string", []any{"destination", "bogus", "k", "v"}, logging.DestinationGeneral, []any{"k", "v"}},
+		{"dangling-key", []any{"k", "v", "odd"}, logging.DestinationGeneral, []any{"k", "v", "odd"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dest, args := extractDestination(tc.args)
+			if dest != tc.wantDest {
+				t.Errorf("dest = %v, want %v", dest, tc.wantDest)
+			}
+			if len(args) != len(tc.wantArgs) {
+				t.Fatalf("args = %v, want %v", args, tc.wantArgs)
+			}
+			for i := range args {
+				if args[i] != tc.wantArgs[i] {
+					t.Errorf("args[%d] = %v, want %v", i, args[i], tc.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSlogBridgeRoutesDestination is the regression for the duplicate-log bug: a plain-slog
+// caller (like cedar) that tags a record destination=cedar must (1) be routed to the cedar
+// destination — so its default Warn level suppresses Info chatter — and (2) never produce a
+// record carrying two destination attributes.
+func TestSlogBridgeRoutesDestination(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bridge.log")
+	l, err := logging.New(&logging.Config{
+		OutputPath:        path,
+		SkipGlobalInstall: true,
+		DestinationLevels: map[logging.Destination]logging.Verbosity{logging.DestinationCedar: logging.VerbosityWarn},
+		DefaultLevel:      logging.VerbosityInfo,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sl := slog.New(&slogBridge{log: l})
+
+	// Cedar Info -> routed to cedar (Warn) -> suppressed, exactly as in production where the
+	// bug let this handshake chatter leak into the General stream.
+	sl.Info("cedar session resumed", "destination", "cedar")
+	// General Info -> logged, with a single destination attribute.
+	sl.Info("general startup", "destination", "general", "k", "v")
+	// Cedar Warn -> logged (at/above its level).
+	sl.Warn("cedar warning", "destination", "cedar")
+
+	out := readFile(t, path)
+
+	if strings.Contains(out, "cedar session resumed") {
+		t.Errorf("cedar Info leaked past the Warn suppression:\n%s", out)
+	}
+	if !strings.Contains(out, "general startup") {
+		t.Errorf("general Info missing:\n%s", out)
+	}
+	if !strings.Contains(out, "cedar warning") {
+		t.Errorf("cedar Warn missing:\n%s", out)
+	}
+	// No record may carry two destination attributes (the reported symptom).
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.Count(line, "destination=") > 1 {
+			t.Errorf("line has duplicate destination attributes: %q", line)
+		}
+	}
+	// The general line must be tagged cedar-free and general-tagged.
+	if !strings.Contains(out, "destination=general") {
+		t.Errorf("general line not tagged destination=general:\n%s", out)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/daemon/slog_test.go
+++ b/daemon/slog_test.go
@@ -91,6 +91,7 @@ func TestSlogBridgeRoutesDestination(t *testing.T) {
 
 func readFile(t *testing.T, path string) string {
 	t.Helper()
+	//nolint:gosec // G304: test-only, path is a t.TempDir() file
 	b, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -8,7 +8,7 @@ require github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0 // indirect
-	github.com/bbockelm/cedar v0.5.5 // indirect
+	github.com/bbockelm/cedar v0.5.7 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/examples/basic/go.sum
+++ b/examples/basic/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.5.5 h1:IWkP5DjKpcwayo/O+BV+yFUCaHV/Uo6g0huYYKNhRnI=
-github.com/bbockelm/cedar v0.5.5/go.mod h1:xzqomHCxjE/F9J5Wf6I/VJ/ZM6XHed4bhZEqhwlqCLY=
+github.com/bbockelm/cedar v0.5.7 h1:DuAYf5Rr1GFlTajrRzmVlJSl+uR0h9bUXCWuUf/aDY0=
+github.com/bbockelm/cedar v0.5.7/go.mod h1:/5WscPQW79bV7Y3VQh6z0NHNp6fkx5NJUcv/hAlGQv4=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/examples/file_transfer_demo/go.mod
+++ b/examples/file_transfer_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/bbockelm/golang-htcondor => ../..
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0
-	github.com/bbockelm/cedar v0.5.5
+	github.com/bbockelm/cedar v0.5.7
 	github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/file_transfer_demo/go.sum
+++ b/examples/file_transfer_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.5.5 h1:IWkP5DjKpcwayo/O+BV+yFUCaHV/Uo6g0huYYKNhRnI=
-github.com/bbockelm/cedar v0.5.5/go.mod h1:xzqomHCxjE/F9J5Wf6I/VJ/ZM6XHed4bhZEqhwlqCLY=
+github.com/bbockelm/cedar v0.5.7 h1:DuAYf5Rr1GFlTajrRzmVlJSl+uR0h9bUXCWuUf/aDY0=
+github.com/bbockelm/cedar v0.5.7/go.mod h1:/5WscPQW79bV7Y3VQh6z0NHNp6fkx5NJUcv/hAlGQv4=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/examples/queue_demo/go.mod
+++ b/examples/queue_demo/go.mod
@@ -13,7 +13,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0 // indirect
-	github.com/bbockelm/cedar v0.5.5 // indirect
+	github.com/bbockelm/cedar v0.5.7 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/examples/queue_demo/go.sum
+++ b/examples/queue_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.5.5 h1:IWkP5DjKpcwayo/O+BV+yFUCaHV/Uo6g0huYYKNhRnI=
-github.com/bbockelm/cedar v0.5.5/go.mod h1:xzqomHCxjE/F9J5Wf6I/VJ/ZM6XHed4bhZEqhwlqCLY=
+github.com/bbockelm/cedar v0.5.7 h1:DuAYf5Rr1GFlTajrRzmVlJSl+uR0h9bUXCWuUf/aDY0=
+github.com/bbockelm/cedar v0.5.7/go.mod h1:/5WscPQW79bV7Y3VQh6z0NHNp6fkx5NJUcv/hAlGQv4=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/examples/security_config/go.mod
+++ b/examples/security_config/go.mod
@@ -3,7 +3,7 @@ module github.com/bbockelm/golang-htcondor/examples/security_config
 go 1.25.7
 
 require (
-	github.com/bbockelm/cedar v0.5.5
+	github.com/bbockelm/cedar v0.5.7
 	github.com/bbockelm/golang-htcondor v0.0.0-20251113012241-ab2a8efb0537
 )
 

--- a/examples/security_config/go.sum
+++ b/examples/security_config/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.5.5 h1:IWkP5DjKpcwayo/O+BV+yFUCaHV/Uo6g0huYYKNhRnI=
-github.com/bbockelm/cedar v0.5.5/go.mod h1:xzqomHCxjE/F9J5Wf6I/VJ/ZM6XHed4bhZEqhwlqCLY=
+github.com/bbockelm/cedar v0.5.7 h1:DuAYf5Rr1GFlTajrRzmVlJSl+uR0h9bUXCWuUf/aDY0=
+github.com/bbockelm/cedar v0.5.7/go.mod h1:/5WscPQW79bV7Y3VQh6z0NHNp6fkx5NJUcv/hAlGQv4=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/examples/submit_demo/go.mod
+++ b/examples/submit_demo/go.mod
@@ -6,7 +6,7 @@ require github.com/bbockelm/golang-htcondor v0.0.0
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0 // indirect
-	github.com/bbockelm/cedar v0.5.5 // indirect
+	github.com/bbockelm/cedar v0.5.7 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/examples/submit_demo/go.sum
+++ b/examples/submit_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.5.5 h1:IWkP5DjKpcwayo/O+BV+yFUCaHV/Uo6g0huYYKNhRnI=
-github.com/bbockelm/cedar v0.5.5/go.mod h1:xzqomHCxjE/F9J5Wf6I/VJ/ZM6XHed4bhZEqhwlqCLY=
+github.com/bbockelm/cedar v0.5.7 h1:DuAYf5Rr1GFlTajrRzmVlJSl+uR0h9bUXCWuUf/aDY0=
+github.com/bbockelm/cedar v0.5.7/go.mod h1:/5WscPQW79bV7Y3VQh6z0NHNp6fkx5NJUcv/hAlGQv4=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0
-	github.com/bbockelm/cedar v0.5.5
+	github.com/bbockelm/cedar v0.5.7
 	github.com/bbockelm/gosssd v0.0.1
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
 github.com/bbockelm/cedar v0.5.5 h1:IWkP5DjKpcwayo/O+BV+yFUCaHV/Uo6g0huYYKNhRnI=
 github.com/bbockelm/cedar v0.5.5/go.mod h1:xzqomHCxjE/F9J5Wf6I/VJ/ZM6XHed4bhZEqhwlqCLY=
+github.com/bbockelm/cedar v0.5.7 h1:DuAYf5Rr1GFlTajrRzmVlJSl+uR0h9bUXCWuUf/aDY0=
+github.com/bbockelm/cedar v0.5.7/go.mod h1:/5WscPQW79bV7Y3VQh6z0NHNp6fkx5NJUcv/hAlGQv4=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/PelicanPlatform/classad/collections v0.8.0 h1:qlNkYij8O52beqb0ekrYKrC
 github.com/PelicanPlatform/classad/collections v0.8.0/go.mod h1:djT/JhGuLcMnVyXOsdiniPzZC6NaxQz8ZHTkffYZtNY=
 github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5UCbeKB4UQ4=
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
-github.com/bbockelm/cedar v0.5.5 h1:IWkP5DjKpcwayo/O+BV+yFUCaHV/Uo6g0huYYKNhRnI=
-github.com/bbockelm/cedar v0.5.5/go.mod h1:xzqomHCxjE/F9J5Wf6I/VJ/ZM6XHed4bhZEqhwlqCLY=
 github.com/bbockelm/cedar v0.5.7 h1:DuAYf5Rr1GFlTajrRzmVlJSl+uR0h9bUXCWuUf/aDY0=
 github.com/bbockelm/cedar v0.5.7/go.mod h1:/5WscPQW79bV7Y3VQh6z0NHNp6fkx5NJUcv/hAlGQv4=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=

--- a/localcredmon/go.mod
+++ b/localcredmon/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0 // indirect
-	github.com/bbockelm/cedar v0.5.5 // indirect
+	github.com/bbockelm/cedar v0.5.7 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/crypto v0.54.0 // indirect

--- a/localcredmon/go.sum
+++ b/localcredmon/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.5.5 h1:IWkP5DjKpcwayo/O+BV+yFUCaHV/Uo6g0huYYKNhRnI=
-github.com/bbockelm/cedar v0.5.5/go.mod h1:xzqomHCxjE/F9J5Wf6I/VJ/ZM6XHed4bhZEqhwlqCLY=
+github.com/bbockelm/cedar v0.5.7 h1:DuAYf5Rr1GFlTajrRzmVlJSl+uR0h9bUXCWuUf/aDY0=
+github.com/bbockelm/cedar v0.5.7/go.mod h1:/5WscPQW79bV7Y3VQh6z0NHNp6fkx5NJUcv/hAlGQv4=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -381,6 +381,7 @@ func New(config *Config) (*Logger, error) {
 		}
 
 		// 0644 to match C++ HTCondor's world-readable daemon logs.
+		//nolint:gosec // G302: daemon logs are intentionally world-readable, as in C++ HTCondor
 		f, err := os.OpenFile(config.OutputPath, flags, 0644)
 		if err != nil {
 			// If we can't open the log file (permission denied, etc.), fall back to stdout
@@ -712,18 +713,6 @@ func (l *Logger) shouldLog(dest Destination, msgLevel Verbosity) bool {
 func (l *Logger) buildFilteredLogger(w io.Writer) *slog.Logger {
 	base := slog.NewTextHandler(w, &slog.HandlerOptions{Level: slog.LevelDebug})
 	return slog.New(&filteringHandler{handler: base, levels: &l.levels})
-}
-
-// currentWriter returns the Logger's current output writer (the open log file, or
-// stdout/stderr), so a live handler rebuild targets the same destination.
-func (l *Logger) currentWriter() io.Writer {
-	if f := l.logFile.Load(); f != nil {
-		return f
-	}
-	if strings.EqualFold(l.config.OutputPath, "stdout") || l.config.OutputPath == "" {
-		return os.Stdout
-	}
-	return os.Stderr
 }
 
 // ApplyLevels replaces the live per-destination verbosity configuration. Because the

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -92,6 +92,7 @@ type Config struct {
 // Logger wraps slog.Logger with destination and verbosity filtering
 type Logger struct {
 	config       *Config
+	levels       atomic.Pointer[levelSet]    // Live per-destination levels; swapped by ApplyLevels
 	logger       atomic.Pointer[slog.Logger] // Atomic pointer to allow handler updates
 	logFile      atomic.Pointer[os.File]     // Atomic pointer to current log file (nil for stdout/stderr)
 	currentSize  atomic.Int64                // Current size of log file
@@ -235,11 +236,32 @@ func sanitizeOutputPath(outputPath string) string {
 	return outputPath
 }
 
-// filteringHandler wraps an slog.Handler and filters messages based on destination attributes
-type filteringHandler struct {
-	handler           slog.Handler
+// levelSet is an immutable snapshot of the per-destination verbosity configuration.
+// It is swapped atomically (see Logger.levels) so log levels can be re-applied live on
+// condor_reconfig without racing concurrent log calls: readers Load() a consistent
+// snapshot, ApplyLevels Store()s a fresh one.
+type levelSet struct {
 	destinationLevels map[Destination]Verbosity
 	defaultLevel      Verbosity
+}
+
+// levelFor returns the configured verbosity for dest, falling back to the default.
+func (ls *levelSet) levelFor(dest Destination) Verbosity {
+	if ls.destinationLevels != nil {
+		if level, ok := ls.destinationLevels[dest]; ok {
+			return level
+		}
+	}
+	return ls.defaultLevel
+}
+
+// filteringHandler wraps an slog.Handler and filters messages based on destination attributes.
+// It reads the current levels through a shared atomic pointer so a level reconfig takes
+// effect for handlers already installed (including the process-global default and any
+// post-rotation handler).
+type filteringHandler struct {
+	handler slog.Handler
+	levels  *atomic.Pointer[levelSet]
 }
 
 // Enabled checks if a log level should be enabled based on destination filtering
@@ -266,12 +288,12 @@ func (h *filteringHandler) Handle(ctx context.Context, r slog.Record) error {
 		return true // Continue iteration
 	})
 
-	// Determine configured level for this destination
-	configuredLevel := h.defaultLevel
-	if found && h.destinationLevels != nil {
-		if level, ok := h.destinationLevels[dest]; ok {
-			configuredLevel = level
-		}
+	// Determine configured level for this destination (from the live snapshot). An
+	// unrecognized/absent destination attribute falls back to the default level.
+	ls := h.levels.Load()
+	configuredLevel := ls.defaultLevel
+	if found {
+		configuredLevel = ls.levelFor(dest)
 	}
 
 	// Convert slog level to our Verbosity
@@ -297,18 +319,16 @@ func (h *filteringHandler) Handle(ctx context.Context, r slog.Record) error {
 // WithAttrs returns a new handler with additional attributes
 func (h *filteringHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &filteringHandler{
-		handler:           h.handler.WithAttrs(attrs),
-		destinationLevels: h.destinationLevels,
-		defaultLevel:      h.defaultLevel,
+		handler: h.handler.WithAttrs(attrs),
+		levels:  h.levels,
 	}
 }
 
 // WithGroup returns a new handler with a group name
 func (h *filteringHandler) WithGroup(name string) slog.Handler {
 	return &filteringHandler{
-		handler:           h.handler.WithGroup(name),
-		destinationLevels: h.destinationLevels,
-		defaultLevel:      h.defaultLevel,
+		handler: h.handler.WithGroup(name),
+		levels:  h.levels,
 	}
 }
 
@@ -360,7 +380,8 @@ func New(config *Config) (*Logger, error) {
 			flags |= os.O_APPEND
 		}
 
-		f, err := os.OpenFile(config.OutputPath, flags, 0600)
+		// 0644 to match C++ HTCondor's world-readable daemon logs.
+		f, err := os.OpenFile(config.OutputPath, flags, 0644)
 		if err != nil {
 			// If we can't open the log file (permission denied, etc.), fall back to stdout
 			// This can happen if the directory doesn't exist or we don't have write permission
@@ -386,46 +407,26 @@ func New(config *Config) (*Logger, error) {
 		}
 	}
 
-	// Set slog handler to capture all log levels (Debug)
-	// Use filteringHandler for per-destination filtering
-	// This ensures both our Logger methods and direct slog calls get filtered
-	slogLevel := slog.LevelDebug
-
-	// Create slog handler with options
-	opts := &slog.HandlerOptions{
-		Level: slogLevel,
-	}
-
-	baseHandler := slog.NewTextHandler(writer, opts)
-	filtHandler := &filteringHandler{
-		handler:           baseHandler,
-		destinationLevels: config.DestinationLevels,
-		defaultLevel:      config.DefaultLevel,
-	}
-	logger := slog.New(filtHandler)
-
+	// Build the Logger and publish its initial level snapshot. Handlers reference
+	// &l.levels (not a copy), so ApplyLevels can swap levels live for handlers already
+	// installed -- including the process-global default below and any post-rotation one.
 	l := &Logger{
 		config: config,
 	}
-	l.logger.Store(logger)
+	l.levels.Store(&levelSet{
+		destinationLevels: config.DestinationLevels,
+		defaultLevel:      config.DefaultLevel,
+	})
+	l.logger.Store(l.buildFilteredLogger(writer))
 	l.logFile.Store(logFile)
 	l.currentSize.Store(currentSize)
 
 	// By default, set as global default so external dependencies (like Cedar) use our logger
 	// Skip if SkipGlobalInstall is true
 	if !config.SkipGlobalInstall {
-		// Use a filtering handler that accepts DEBUG level but filters based on destination
-		// This allows Cedar logs with destination=cedar to be filtered appropriately
-		globalOpts := &slog.HandlerOptions{
-			Level: slog.LevelDebug, // Accept all levels
-		}
-		globalBaseHandler := slog.NewTextHandler(writer, globalOpts)
-		globalFilteringHandler := &filteringHandler{
-			handler:           globalBaseHandler,
-			destinationLevels: config.DestinationLevels,
-			defaultLevel:      config.DefaultLevel,
-		}
-		slog.SetDefault(slog.New(globalFilteringHandler))
+		// A filtering handler that accepts DEBUG level but filters per destination, so Cedar
+		// logs tagged destination=cedar are filtered appropriately.
+		slog.SetDefault(l.buildFilteredLogger(writer))
 	}
 
 	return l, nil
@@ -457,6 +458,51 @@ func parseLevel(level string) Verbosity {
 
 	// Default to warn
 	return VerbosityWarn
+}
+
+// DefaultDaemonLevel is the fallback verbosity for destinations without an explicit
+// <DAEMON>_DEBUG entry, matching HTCondor's "D_ALWAYS shows up by default" baseline so an
+// unconfigured daemon still logs routine activity. Used by both startup and reconfig.
+const DefaultDaemonLevel = VerbosityInfo
+
+// ParseDestinationLevels parses a daemon's <DAEMON>_DEBUG configuration into a
+// per-destination verbosity map. The cedar destination defaults to Warn (its per-step Info
+// chatter logs sensitive session IDs and is very noisy; operators opt in via
+// <DAEMON>_DEBUG = cedar:debug). Shared by FromConfigWithDaemon (startup) and the daemon's
+// reconfig path so both derive levels identically from the same config.
+func ParseDestinationLevels(daemonName string, cfg *config.Config) map[Destination]Verbosity {
+	levels := map[Destination]Verbosity{
+		DestinationCedar: VerbosityWarn,
+	}
+	if cfg == nil {
+		return levels
+	}
+	debugParam := strings.ToUpper(daemonName) + "_DEBUG"
+	debugConfig, ok := cfg.Get(debugParam)
+	if !ok || debugConfig == "" {
+		return levels
+	}
+	// Split by comma or whitespace into destination:level pairs.
+	for _, pair := range strings.Fields(strings.ReplaceAll(debugConfig, ",", " ")) {
+		parts := strings.SplitN(pair, ":", 2)
+		if len(parts) != 2 {
+			continue // Skip malformed pairs
+		}
+		dest, ok := parseDestination(parts[0])
+		if !ok {
+			continue // Skip unknown destinations
+		}
+		levels[dest] = parseLevel(parts[1])
+	}
+	return levels
+}
+
+// ParseDestination converts a destination string (e.g. "cedar", "general") to a
+// Destination. The bool is false for an empty or unknown string, in which case the
+// returned Destination is DestinationGeneral. Exported for the daemon slog bridge, which
+// routes a record to the destination its "destination" attribute names.
+func ParseDestination(dest string) (Destination, bool) {
+	return parseDestination(dest)
 }
 
 // parseDestination converts a destination string to a Destination constant.
@@ -555,31 +601,7 @@ func FromConfigWithDaemon(daemonName string, cfg *config.Config) (*Logger, error
 	// Operators who need cedar Info or Debug can opt in via
 	//   HTTP_API_DEBUG = cedar:debug
 	// in their condor config.
-	destinationLevels := map[Destination]Verbosity{
-		DestinationCedar: VerbosityWarn,
-	}
-	debugParam := strings.ToUpper(daemonName) + "_DEBUG"
-	if debugConfig, ok := cfg.Get(debugParam); ok && debugConfig != "" {
-		// Split by comma or whitespace
-		debugConfig = strings.ReplaceAll(debugConfig, ",", " ")
-		pairs := strings.Fields(debugConfig)
-
-		for _, pair := range pairs {
-			// Split by colon
-			parts := strings.SplitN(pair, ":", 2)
-			if len(parts) != 2 {
-				continue // Skip malformed pairs
-			}
-
-			dest, ok := parseDestination(parts[0])
-			if !ok {
-				continue // Skip unknown destinations
-			}
-
-			level := parseLevel(parts[1])
-			destinationLevels[dest] = level
-		}
-	}
+	destinationLevels := ParseDestinationLevels(daemonName, cfg)
 
 	// Parse rotation parameters
 	maxLogSize := int64(DefaultMaxLogSize)
@@ -668,18 +690,52 @@ func FromConfig(cfg *config.Config) (*Logger, error) {
 	})
 }
 
+// currentLevels returns the live level snapshot, falling back to the static config for a
+// Logger constructed as a struct literal (i.e. not via New(), so levels was never stored).
+func (l *Logger) currentLevels() *levelSet {
+	if ls := l.levels.Load(); ls != nil {
+		return ls
+	}
+	return &levelSet{destinationLevels: l.config.DestinationLevels, defaultLevel: l.config.DefaultLevel}
+}
+
 // shouldLog checks if a log should be written based on destination-specific verbosity level
 func (l *Logger) shouldLog(dest Destination, msgLevel Verbosity) bool {
-	// Get the configured level for this destination (use DefaultLevel if not configured)
-	configuredLevel := l.config.DefaultLevel
-	if l.config.DestinationLevels != nil {
-		if level, ok := l.config.DestinationLevels[dest]; ok {
-			configuredLevel = level
-		}
-	}
+	// Only log if message level is at or below the destination's configured level
+	// (from the live snapshot).
+	return msgLevel <= l.currentLevels().levelFor(dest)
+}
 
-	// Only log if message level is at or below configured level
-	return msgLevel <= configuredLevel
+// buildFilteredLogger wraps w in a per-destination filtering handler bound to this
+// Logger's live level snapshot (&l.levels). Used at construction, on log rotation, and
+// for the process-global default so every path shares one dynamically-updatable level set.
+func (l *Logger) buildFilteredLogger(w io.Writer) *slog.Logger {
+	base := slog.NewTextHandler(w, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(&filteringHandler{handler: base, levels: &l.levels})
+}
+
+// currentWriter returns the Logger's current output writer (the open log file, or
+// stdout/stderr), so a live handler rebuild targets the same destination.
+func (l *Logger) currentWriter() io.Writer {
+	if f := l.logFile.Load(); f != nil {
+		return f
+	}
+	if strings.EqualFold(l.config.OutputPath, "stdout") || l.config.OutputPath == "" {
+		return os.Stdout
+	}
+	return os.Stderr
+}
+
+// ApplyLevels replaces the live per-destination verbosity configuration. Because the
+// installed handlers (local, process-global, post-rotation) all read levels through the
+// shared atomic pointer, this single swap re-applies levels everywhere with no handler
+// rebuild -- the mechanism condor_reconfig uses to change log levels on a running daemon.
+// A nil destinationLevels means "all destinations use defaultLevel".
+func (l *Logger) ApplyLevels(destinationLevels map[Destination]Verbosity, defaultLevel Verbosity) {
+	l.levels.Store(&levelSet{
+		destinationLevels: destinationLevels,
+		defaultLevel:      defaultLevel,
+	})
 }
 
 // destinationString returns a string representation of the destination
@@ -771,9 +827,9 @@ func (l *Logger) rotateLogIfNeeded() error {
 		return fmt.Errorf("failed to rename current log to .old: %w", err)
 	}
 
-	// Create new log file
+	// Create new log file (0644 to match C++ HTCondor's world-readable daemon logs).
 	//nolint:gosec // G304 - logPath is internal to logger, not user-controlled
-	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to create new log file: %w", err)
 	}
@@ -782,17 +838,9 @@ func (l *Logger) rotateLogIfNeeded() error {
 	l.logFile.Store(f)
 	l.currentSize.Store(0)
 
-	// Create new handler and logger with the new file
-	// Set slog handler to capture all log levels (Debug)
-	// Per-destination filtering happens in filteringHandler
-	slogLevel := slog.LevelDebug
-
-	opts := &slog.HandlerOptions{
-		Level: slogLevel,
-	}
-	handler := slog.NewTextHandler(f, opts)
-	newLogger := slog.New(handler)
-	l.logger.Store(newLogger)
+	// Rebuild through the per-destination filtering handler (bound to the live level
+	// snapshot) so post-rotation direct-slog calls stay filtered.
+	l.logger.Store(l.buildFilteredLogger(f))
 
 	return nil
 }
@@ -857,9 +905,9 @@ func (l *Logger) PerformMaintenance() error {
 func (l *Logger) reopenLogFile() error {
 	logPath := l.config.OutputPath
 
-	// Open new file
+	// Open new file (0644 to match C++ HTCondor's world-readable daemon logs).
 	//nolint:gosec // G304 - logPath is internal to logger, not user-controlled
-	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to reopen log file: %w", err)
 	}
@@ -880,17 +928,10 @@ func (l *Logger) reopenLogFile() error {
 	// Reset size to current file size
 	l.currentSize.Store(stat.Size())
 
-	// Create new handler and logger with the new file
-	// Set slog handler to capture all log levels (Debug)
-	// Per-destination filtering happens in filteringHandler
-	slogLevel := slog.LevelDebug
-
-	opts := &slog.HandlerOptions{
-		Level: slogLevel,
-	}
-	handler := slog.NewTextHandler(f, opts)
-	newLogger := slog.New(handler)
-	l.logger.Store(newLogger)
+	// Rebuild through the per-destination filtering handler (bound to the live level
+	// snapshot) so post-rotation direct-slog calls stay filtered -- a bare TextHandler
+	// here would bypass per-destination levels after every rotation.
+	l.logger.Store(l.buildFilteredLogger(f))
 
 	return nil
 }

--- a/logging/reconfig_test.go
+++ b/logging/reconfig_test.go
@@ -30,6 +30,7 @@ func newTestConfig(t *testing.T, params map[string]string) *config.Config {
 // readLog returns the contents of a logger's file output.
 func readLog(t *testing.T, path string) string {
 	t.Helper()
+	//nolint:gosec // G304: test-only, path is a t.TempDir() file
 	b, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read log: %v", err)

--- a/logging/reconfig_test.go
+++ b/logging/reconfig_test.go
@@ -1,0 +1,110 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/bbockelm/golang-htcondor/config"
+)
+
+// newTestConfig builds a config from the given param map (nil for empty).
+func newTestConfig(t *testing.T, params map[string]string) *config.Config {
+	t.Helper()
+	var b strings.Builder
+	for k, v := range params {
+		b.WriteString(k)
+		b.WriteString(" = ")
+		b.WriteString(v)
+		b.WriteString("\n")
+	}
+	cfg, err := config.NewFromReader(strings.NewReader(b.String()))
+	if err != nil {
+		t.Fatalf("build config: %v", err)
+	}
+	return cfg
+}
+
+// readLog returns the contents of a logger's file output.
+func readLog(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	return string(b)
+}
+
+// TestApplyLevelsLive verifies condor_reconfig's mechanism: a destination suppressed at
+// startup begins logging after ApplyLevels raises its level, on the already-constructed
+// logger, with no handler rebuild.
+func TestApplyLevelsLive(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.log")
+	l, err := New(&Config{
+		OutputPath:        path,
+		SkipGlobalInstall: true,
+		DestinationLevels: map[Destination]Verbosity{DestinationCedar: VerbosityWarn},
+		DefaultLevel:      VerbosityInfo,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l.Info(DestinationCedar, "cedar-before") // Info < Warn config -> suppressed
+	if got := readLog(t, path); strings.Contains(got, "cedar-before") {
+		t.Fatalf("cedar Info should be suppressed at Warn, got: %q", got)
+	}
+
+	// Reconfig raises cedar to Debug (like COLLECTOR_DEBUG = cedar:debug).
+	l.ApplyLevels(map[Destination]Verbosity{DestinationCedar: VerbosityDebug}, VerbosityInfo)
+
+	l.Info(DestinationCedar, "cedar-after")
+	if got := readLog(t, path); !strings.Contains(got, "cedar-after") {
+		t.Fatalf("cedar Info should log after ApplyLevels raised the level, got: %q", got)
+	}
+}
+
+// TestParseDestinationLevels covers the shared <DAEMON>_DEBUG parser used by both startup
+// and reconfig, including the cedar=Warn default and an explicit override.
+func TestParseDestinationLevels(t *testing.T) {
+	cfg := newTestConfig(t, map[string]string{
+		"COLLECTOR_DEBUG": "cedar:debug, http:info",
+	})
+	levels := ParseDestinationLevels("COLLECTOR", cfg)
+	if levels[DestinationCedar] != VerbosityDebug {
+		t.Errorf("cedar = %v, want Debug (explicit override)", levels[DestinationCedar])
+	}
+	if levels[DestinationHTTP] != VerbosityInfo {
+		t.Errorf("http = %v, want Info", levels[DestinationHTTP])
+	}
+
+	// With no <DAEMON>_DEBUG, cedar still defaults to Warn (session-ID/chatter suppression).
+	bare := ParseDestinationLevels("COLLECTOR", newTestConfig(t, nil))
+	if bare[DestinationCedar] != VerbosityWarn {
+		t.Errorf("default cedar = %v, want Warn", bare[DestinationCedar])
+	}
+}
+
+// TestLogFileMode0644 verifies daemon logs are created world-readable (matching C++
+// HTCondor), not 0600. Umask is cleared so the mode is deterministic.
+func TestLogFileMode0644(t *testing.T) {
+	old := syscall.Umask(0)
+	defer syscall.Umask(old)
+
+	path := filepath.Join(t.TempDir(), "mode.log")
+	l, err := New(&Config{OutputPath: path, SkipGlobalInstall: true, DefaultLevel: VerbosityInfo})
+	if err != nil {
+		t.Fatal(err)
+	}
+	l.Info(DestinationGeneral, "hi")
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0644 {
+		t.Fatalf("log file mode = %o, want 0644", perm)
+	}
+}

--- a/security.go
+++ b/security.go
@@ -422,27 +422,60 @@ func getSecurityLevel(cfg *config.Config, context, feature string) string {
 // getSecurityMethods retrieves a comma-separated list of security methods
 // For example: SEC_CLIENT_AUTHENTICATION_METHODS, falling back to SEC_DEFAULT_AUTHENTICATION_METHODS
 func getSecurityMethods(cfg *config.Config, context, feature string) string {
-	// Try context-specific setting first
-	contextKey := fmt.Sprintf("SEC_%s_%s", context, feature)
-	if value, ok := cfg.Get(contextKey); ok {
+	// An operator's context-specific setting always wins.
+	if value, ok := cfg.Get(fmt.Sprintf("SEC_%s_%s", context, feature)); ok && value != "" {
 		return value
 	}
 
-	// Fall back to DEFAULT setting
-	defaultKey := fmt.Sprintf("SEC_DEFAULT_%s", feature)
-	if value, ok := cfg.Get(defaultKey); ok {
-		return value
-	}
-
-	// Return HTCondor's default based on platform
 	switch feature {
 	case "AUTHENTICATION_METHODS":
-		return getDefaultAuthMethods()
+		// An operator's SEC_DEFAULT_AUTHENTICATION_METHODS wins -- but ignore the stale
+		// generated-table value (staleGeneratedAuthDefault, from before TOKEN split into
+		// IDTOKENS/SCITOKENS) so it cannot shadow the programmatic default. There is no
+		// standalone param_info.in default for this key, so a resolved value is either the
+		// operator's or that one stale generated artifact.
+		methods := getDefaultAuthMethods()
+		if v, ok := cfg.Get("SEC_DEFAULT_AUTHENTICATION_METHODS"); ok && v != "" && !isStaleAuthDefault(v) {
+			methods = v
+		}
+		// CLIENT and READ contexts append ANONYMOUS (an auth method that does not actually
+		// authenticate) so an encrypted-but-unauthenticated READ works -- matching
+		// HTCondor's SEC_CLIENT/READ_AUTHENTICATION_METHODS = $(SEC_DEFAULT_...),ANONYMOUS.
+		if context == "CLIENT" || context == "READ" {
+			methods = appendMethod(methods, "ANONYMOUS")
+		}
+		return methods
 	case "CRYPTO_METHODS":
-		return "AES" // HTCondor 9.0+ default
+		if value, ok := cfg.Get("SEC_DEFAULT_CRYPTO_METHODS"); ok && value != "" {
+			return value
+		}
+		return "AES" // HTCondor 9.0+ default; cedar implements AES-GCM only
 	}
 
 	return ""
+}
+
+// staleGeneratedAuthDefault is the value the generated param table ships for
+// SEC_DEFAULT_AUTHENTICATION_METHODS (param_defaults.go). It predates HTCondor splitting
+// TOKEN into IDTOKENS/SCITOKENS and adding SSL, so it must not be treated as a configured
+// default; getSecurityMethods substitutes the programmatic default when it sees this value.
+const staleGeneratedAuthDefault = "FS,TOKEN"
+
+func isStaleAuthDefault(v string) bool {
+	return strings.EqualFold(strings.ReplaceAll(v, " ", ""), staleGeneratedAuthDefault)
+}
+
+// appendMethod appends name to a comma-separated method list if not already present.
+func appendMethod(list, name string) string {
+	for _, m := range strings.Split(list, ",") {
+		if strings.EqualFold(strings.TrimSpace(m), name) {
+			return list
+		}
+	}
+	if list == "" {
+		return name
+	}
+	return list + "," + name
 }
 
 // getDefaultAuthMethods returns the fallback authentication-methods
@@ -460,12 +493,39 @@ func getSecurityMethods(cfg *config.Config, context, feature string) string {
 // IDTOKENS were filtered by `iss`/`kid` mismatch, and the handshake
 // failed with "no compatible authentication methods found" even
 // though SSL was available on both sides.
+// authMethodStdOrder is HTCondor's standard authentication-method precedence, mirroring
+// the C++ SEC_STD_AUTH_METHOD_NAMES macro (condor_utils/param_info.cpp): FS, IDTOKENS,
+// PASSWORD, KERBEROS, SCITOKENS, SSL. cedar's negotiation walks the list in order, trying
+// each in turn (FS cheap-when-applicable first, SSL the broadest fallback last).
+var authMethodStdOrder = []string{"FS", "IDTOKENS", "PASSWORD", "KERBEROS", "SCITOKENS", "SSL"}
+
+// getDefaultAuthMethods builds the default authentication-method list programmatically: the
+// standard order above, filtered to the methods cedar actually implements. This is the Go
+// analogue of C++ building SEC_STD_AUTH_METHOD_NAMES from compile-time HAVE_EXT_* flags --
+// offering a method cedar cannot perform would just make negotiation fail. Today it yields
+// "FS,IDTOKENS,SCITOKENS,SSL"; PASSWORD and KERBEROS join automatically once cedar
+// implements them (see cedarImplementsAuthMethod).
 func getDefaultAuthMethods() string {
-	// Unix/Linux/macOS default. The order matters: cedar's
-	// negotiation walks the list and tries each method in turn, so
-	// FS goes first (cheap when applicable) and SSL last (more
-	// expensive but the broadest fallback).
-	return "FS,IDTOKENS,KERBEROS,SCITOKENS,SSL"
+	var out []string
+	for _, m := range authMethodStdOrder {
+		if cedarImplementsAuthMethod(m) {
+			out = append(out, m)
+		}
+	}
+	return strings.Join(out, ",")
+}
+
+// cedarImplementsAuthMethod reports whether cedar has a working handshake for the named
+// method. Mirrors golang-cedar's Authenticator.performAuthentication switch (security/
+// auth.go): FS, IDTOKENS, SCITOKENS, SSL have real implementations; KERBEROS and PASSWORD
+// are declared but return "not yet implemented". Update this when cedar implements more.
+func cedarImplementsAuthMethod(name string) bool {
+	switch strings.ToUpper(name) {
+	case "FS", "IDTOKENS", "TOKEN", "SCITOKENS", "SSL":
+		return true
+	default: // KERBEROS, PASSWORD (cedar stubs), and anything unknown
+		return false
+	}
 }
 
 // mapSecurityLevel converts HTCondor security level string to cedar SecurityLevel

--- a/security.go
+++ b/security.go
@@ -493,39 +493,20 @@ func appendMethod(list, name string) string {
 // IDTOKENS were filtered by `iss`/`kid` mismatch, and the handshake
 // failed with "no compatible authentication methods found" even
 // though SSL was available on both sides.
-// authMethodStdOrder is HTCondor's standard authentication-method precedence, mirroring
-// the C++ SEC_STD_AUTH_METHOD_NAMES macro (condor_utils/param_info.cpp): FS, IDTOKENS,
-// PASSWORD, KERBEROS, SCITOKENS, SSL. cedar's negotiation walks the list in order, trying
-// each in turn (FS cheap-when-applicable first, SSL the broadest fallback last).
-var authMethodStdOrder = []string{"FS", "IDTOKENS", "PASSWORD", "KERBEROS", "SCITOKENS", "SSL"}
-
-// getDefaultAuthMethods builds the default authentication-method list programmatically: the
-// standard order above, filtered to the methods cedar actually implements. This is the Go
-// analogue of C++ building SEC_STD_AUTH_METHOD_NAMES from compile-time HAVE_EXT_* flags --
-// offering a method cedar cannot perform would just make negotiation fail. Today it yields
-// "FS,IDTOKENS,SCITOKENS,SSL"; PASSWORD and KERBEROS join automatically once cedar
-// implements them (see cedarImplementsAuthMethod).
+// getDefaultAuthMethods returns the default authentication-method list: HTCondor's standard
+// precedence (SEC_STD_AUTH_METHOD_NAMES) filtered to the methods this build of cedar can
+// actually perform. cedar is the source of truth (security.DefaultAuthMethods), so a method
+// whose handshake is unimplemented (KERBEROS, PASSWORD today) is never offered -- offering it
+// would just make negotiation fail. Yields "FS,IDTOKENS,SCITOKENS,SSL" today; PASSWORD and
+// KERBEROS join automatically once cedar implements them. The names are cedar's config-
+// language spellings (IDTOKENS, not the wire name TOKEN); mapAuthMethods handles the mapping.
 func getDefaultAuthMethods() string {
-	var out []string
-	for _, m := range authMethodStdOrder {
-		if cedarImplementsAuthMethod(m) {
-			out = append(out, m)
-		}
+	methods := security.DefaultAuthMethods()
+	names := make([]string, len(methods))
+	for i, m := range methods {
+		names[i] = string(m)
 	}
-	return strings.Join(out, ",")
-}
-
-// cedarImplementsAuthMethod reports whether cedar has a working handshake for the named
-// method. Mirrors golang-cedar's Authenticator.performAuthentication switch (security/
-// auth.go): FS, IDTOKENS, SCITOKENS, SSL have real implementations; KERBEROS and PASSWORD
-// are declared but return "not yet implemented". Update this when cedar implements more.
-func cedarImplementsAuthMethod(name string) bool {
-	switch strings.ToUpper(name) {
-	case "FS", "IDTOKENS", "TOKEN", "SCITOKENS", "SSL":
-		return true
-	default: // KERBEROS, PASSWORD (cedar stubs), and anything unknown
-		return false
-	}
+	return strings.Join(names, ",")
 }
 
 // mapSecurityLevel converts HTCondor security level string to cedar SecurityLevel

--- a/security_test.go
+++ b/security_test.go
@@ -558,11 +558,12 @@ func TestGetDefaultAuthMethodsProgrammatic(t *testing.T) {
 	if got != "FS,IDTOKENS,SCITOKENS,SSL" {
 		t.Errorf("getDefaultAuthMethods() = %q, want FS,IDTOKENS,SCITOKENS,SSL", got)
 	}
-	if cedarImplementsAuthMethod("KERBEROS") || cedarImplementsAuthMethod("PASSWORD") {
+	// The list is sourced from cedar's capability API: stubs excluded, implemented kept.
+	if security.AuthKerberos.Implemented() || security.AuthPassword.Implemented() {
 		t.Error("KERBEROS/PASSWORD are cedar stubs and must not be reported implemented")
 	}
-	for _, m := range []string{"FS", "IDTOKENS", "SCITOKENS", "SSL"} {
-		if !cedarImplementsAuthMethod(m) {
+	for _, m := range []security.AuthMethod{security.AuthFS, security.AuthIDTokens, security.AuthSciTokens, security.AuthSSL} {
+		if !m.Implemented() {
 			t.Errorf("%s should be reported implemented", m)
 		}
 	}

--- a/security_test.go
+++ b/security_test.go
@@ -32,26 +32,24 @@ func TestGetSecurityConfig_Defaults(t *testing.T) {
 		t.Errorf("Expected Integrity=SecurityOptional, got %v", secConfig.Integrity)
 	}
 
-	// Check default auth methods. The list comes from the
-	// param_overrides.go correction of the auto-generated paramDefaults
-	// (see config/param_overrides.go) and matches HTCondor's actual
-	// built-in default — FS, IDTOKENS, KERBEROS, SCITOKENS, SSL — not
-	// the older FS,IDTOKENS pair. The expanded set is what fixes the
-	// production "no compatible authentication methods found" failure
-	// when the operator hasn't overridden SEC_*_AUTHENTICATION_METHODS.
+	// Check default auth methods. With no operator override, the list is built
+	// programmatically (getDefaultAuthMethods) from the methods cedar actually
+	// implements, in HTCondor's standard order: FS, IDTOKENS, SCITOKENS, SSL. KERBEROS
+	// and PASSWORD are in HTCondor's standard order but cedar does not implement them
+	// (its handshakes return "not yet implemented"), so they are excluded — offering a
+	// method cedar cannot perform would just break negotiation. Because this is the
+	// CLIENT context, ANONYMOUS (cedar's AuthNone) is appended so an encrypted-but-
+	// unauthenticated READ works.
 	//
-	// Note that IDTOKENS in the *config language* maps to cedar's
-	// AuthToken (which serializes on the wire as "TOKEN") — that's
-	// the wire-name every HTCondor schedd / collector recognizes. See
-	// the doc comment on mapAuthMethods for the full rationale; this
-	// used to expect security.AuthIDTokens here, which made the
-	// schedd's SECMAN drop our offer.
+	// Note that IDTOKENS in the *config language* maps to cedar's AuthToken (which
+	// serializes on the wire as "TOKEN") — the wire-name every HTCondor schedd /
+	// collector recognizes. See the doc comment on mapAuthMethods.
 	wantMethods := []security.AuthMethod{
 		security.AuthFS,
 		security.AuthToken,
-		security.AuthKerberos,
 		security.AuthSciTokens,
 		security.AuthSSL,
+		security.AuthNone, // ANONYMOUS, appended for CLIENT/READ
 	}
 	if len(secConfig.AuthMethods) != len(wantMethods) {
 		t.Errorf("Expected %d default auth methods (FS,IDTOKENS→TOKEN,KERBEROS,SCITOKENS,SSL), got %d: %v",
@@ -152,9 +150,11 @@ SEC_DEFAULT_CRYPTO_METHODS = BLOWFISH,3DES
 		t.Errorf("Expected Encryption=SecurityNever from DEFAULT, got %v", secConfig.Encryption)
 	}
 
-	// Check auth methods from DEFAULT
-	if len(secConfig.AuthMethods) != 2 {
-		t.Errorf("Expected 2 auth methods from DEFAULT, got %d", len(secConfig.AuthMethods))
+	// Check auth methods from DEFAULT. CLIENT falls back to SEC_DEFAULT_AUTHENTICATION_METHODS
+	// (KERBEROS,SSL — an operator-set value is respected verbatim, not availability-filtered),
+	// then ANONYMOUS is appended for the CLIENT context: KERBEROS, SSL, ANONYMOUS.
+	if len(secConfig.AuthMethods) != 3 {
+		t.Errorf("Expected 3 auth methods from DEFAULT + ANONYMOUS, got %d: %v", len(secConfig.AuthMethods), secConfig.AuthMethods)
 	}
 
 	// Check crypto methods from DEFAULT
@@ -548,4 +548,52 @@ func TestNewClientSecurityConfig(t *testing.T) {
 			t.Errorf("expected empty context to default to CLIENT, got error: %v", err)
 		}
 	})
+}
+
+// TestGetDefaultAuthMethodsProgrammatic verifies the default auth-method list is built from
+// the methods cedar actually implements: KERBEROS and PASSWORD (cedar stubs) are excluded,
+// FS/IDTOKENS/SCITOKENS/SSL are kept, in HTCondor's standard order.
+func TestGetDefaultAuthMethodsProgrammatic(t *testing.T) {
+	got := getDefaultAuthMethods()
+	if got != "FS,IDTOKENS,SCITOKENS,SSL" {
+		t.Errorf("getDefaultAuthMethods() = %q, want FS,IDTOKENS,SCITOKENS,SSL", got)
+	}
+	if cedarImplementsAuthMethod("KERBEROS") || cedarImplementsAuthMethod("PASSWORD") {
+		t.Error("KERBEROS/PASSWORD are cedar stubs and must not be reported implemented")
+	}
+	for _, m := range []string{"FS", "IDTOKENS", "SCITOKENS", "SSL"} {
+		if !cedarImplementsAuthMethod(m) {
+			t.Errorf("%s should be reported implemented", m)
+		}
+	}
+}
+
+// TestGetSecurityMethodsAuth covers the resolution rules: the stale generated default is
+// ignored in favor of the programmatic one, an operator default is honored, and ANONYMOUS is
+// appended only for CLIENT/READ.
+func TestGetSecurityMethodsAuth(t *testing.T) {
+	prog := getDefaultAuthMethods()
+
+	// No config: stale generated "FS,TOKEN" must NOT surface; CLIENT gets programmatic+ANONYMOUS.
+	cfg, _ := config.NewFromReader(strings.NewReader(""))
+	if got := getSecurityMethods(cfg, "CLIENT", "AUTHENTICATION_METHODS"); got != prog+",ANONYMOUS" {
+		t.Errorf("CLIENT default = %q, want %q", got, prog+",ANONYMOUS")
+	}
+	// WRITE context gets no ANONYMOUS.
+	if got := getSecurityMethods(cfg, "WRITE", "AUTHENTICATION_METHODS"); got != prog {
+		t.Errorf("WRITE default = %q, want %q (no ANONYMOUS)", got, prog)
+	}
+	// An operator SEC_DEFAULT override is honored verbatim (WRITE), plus ANONYMOUS for CLIENT.
+	cfg2, _ := config.NewFromReader(strings.NewReader("SEC_DEFAULT_AUTHENTICATION_METHODS = SSL\n"))
+	if got := getSecurityMethods(cfg2, "WRITE", "AUTHENTICATION_METHODS"); got != "SSL" {
+		t.Errorf("operator WRITE = %q, want SSL", got)
+	}
+	if got := getSecurityMethods(cfg2, "READ", "AUTHENTICATION_METHODS"); got != "SSL,ANONYMOUS" {
+		t.Errorf("operator READ = %q, want SSL,ANONYMOUS", got)
+	}
+	// A context-specific operator setting wins outright (no append beyond what it lists).
+	cfg3, _ := config.NewFromReader(strings.NewReader("SEC_CLIENT_AUTHENTICATION_METHODS = FS\n"))
+	if got := getSecurityMethods(cfg3, "CLIENT", "AUTHENTICATION_METHODS"); got != "FS" {
+		t.Errorf("explicit SEC_CLIENT = %q, want FS", got)
+	}
 }

--- a/webapi/go.mod
+++ b/webapi/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0
-	github.com/bbockelm/cedar v0.5.5
+	github.com/bbockelm/cedar v0.5.7
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/glebarez/sqlite v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/webapi/go.sum
+++ b/webapi/go.sum
@@ -48,8 +48,8 @@ github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQ
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/bbockelm/cedar v0.5.5 h1:IWkP5DjKpcwayo/O+BV+yFUCaHV/Uo6g0huYYKNhRnI=
-github.com/bbockelm/cedar v0.5.5/go.mod h1:xzqomHCxjE/F9J5Wf6I/VJ/ZM6XHed4bhZEqhwlqCLY=
+github.com/bbockelm/cedar v0.5.7 h1:DuAYf5Rr1GFlTajrRzmVlJSl+uR0h9bUXCWuUf/aDY0=
+github.com/bbockelm/cedar v0.5.7/go.mod h1:/5WscPQW79bV7Y3VQh6z0NHNp6fkx5NJUcv/hAlGQv4=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
Five fixes from running the collector/htcondordb in production.

### 1. Bootstrap missing security-method defaults — `config/param_overrides.go`
`SEC_DEFAULT_CRYPTO_METHODS`, `SEC_CLIENT_CRYPTO_METHODS`, `SEC_CLIENT_AUTHENTICATION_METHODS` appear only inside `param_info.in`'s `security:*` metaknobs upstream, never as standalone params — so `cfg.Get` returned false and encryption/auth negotiation survived only on a scattered `"AES"` literal. Added: `AES` (matches HTCondor 9.0+ / cedar's AES-GCM-only reality), client crypto `= $(SEC_DEFAULT_CRYPTO_METHODS)`, client auth `= $(SEC_DEFAULT_AUTHENTICATION_METHODS),ANONYMOUS` (the trailing `ANONYMOUS` enables encrypted-but-unauthenticated READ).

### 2. Duplicate/misrouted log lines — `daemon/slog.go`
The slog bridge forced `DestinationGeneral` **and** passed the record's own `destination` attr through, so a cedar record came out `destination=general destination=cedar` **and** bypassed the cedar destination's Warn-level suppression (spilling per-connection handshake chatter). The bridge now honors the record's destination, routes there, and drops the attribute. Fixes the negotiator + ccb too (shared bridge). Exports `logging.ParseDestination`.

### 3. `condor_reconfig` re-applies log levels — `logging/logging.go`, `daemon/daemon.go`
Levels were frozen at construction (no `LevelVar`) and `reconfigure()` never touched the logger. Levels now live in an `atomic.Pointer[levelSet]` shared by the filtering handler and `shouldLog`; `Logger.ApplyLevels` swaps it live; `reconfigure()` re-parses `<SUBSYS>_DEBUG` and calls it. Also fixes a latent bug: rotation/reopen rebuilt with a **bare** `TextHandler` that bypassed per-destination filtering.

### 4. Log files created `0644`, not `0600`
Matches C++ HTCondor's world-readable daemon logs (3 open sites).

### 5. Preserve subsystem on reconfig — `config/config.go`, `daemon/daemon.go`
`reconfigure()` reloaded via bare `config.New()`, dropping the subsystem so `<SUBSYS>.PARAM` overrides stopped resolving after a SIGHUP. Added `config.Options()` + reload via `NewWithOptions(d.cfg.Load().Options())`. (The client-side half of the subsystem fix is in htcondordb.)

Tests: `logging/reconfig_test.go`, `daemon/slog_test.go`, `config/security_defaults_test.go`. config/daemon/logging suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)