### PR TITLE
security: split SEC_* method lists on whitespace, not just commas

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1125,7 +1125,7 @@ func (c *Config) processLocalConfigDir() error {
 	}
 
 	// Split on comma and/or space
-	dirs := splitConfigList(dirList)
+	dirs := SplitConfigList(dirList)
 
 	// Files whose basename matches LOCAL_CONFIG_DIR_EXCLUDE_REGEXP are skipped --
 	// this is how HTCondor keeps editor backups, package leftovers (.rpmnew,
@@ -1204,7 +1204,7 @@ func (c *Config) processLocalConfigFile() error {
 	}
 
 	// Split on comma and/or space
-	files := splitConfigList(fileList)
+	files := SplitConfigList(fileList)
 
 	for _, file := range files {
 		file = strings.TrimSpace(file)
@@ -1249,8 +1249,11 @@ func (c *Config) processLocalConfigFile() error {
 	return nil
 }
 
-// splitConfigList splits a configuration list on commas and/or spaces
-func splitConfigList(list string) []string {
+// SplitConfigList splits a configuration list on commas and/or spaces -- the
+// delimiters of an HTCondor StringList. Use it for any config value that names a
+// list (auth/crypto methods, directories, ...), so "A,B", "A B", and "A, B" are
+// all equivalent.
+func SplitConfigList(list string) []string {
 	// Replace commas with spaces
 	list = strings.ReplaceAll(list, ",", " ")
 

--- a/security.go
+++ b/security.go
@@ -465,10 +465,10 @@ func isStaleAuthDefault(v string) bool {
 	return strings.EqualFold(strings.ReplaceAll(v, " ", ""), staleGeneratedAuthDefault)
 }
 
-// appendMethod appends name to a comma-separated method list if not already present.
+// appendMethod appends name to a method list if not already present.
 func appendMethod(list, name string) string {
-	for _, m := range strings.Split(list, ",") {
-		if strings.EqualFold(strings.TrimSpace(m), name) {
+	for _, m := range config.SplitConfigList(list) {
+		if strings.EqualFold(m, name) {
 			return list
 		}
 	}
@@ -547,8 +547,8 @@ func mapAuthMethods(methods string) []security.AuthMethod {
 	}
 
 	var result []security.AuthMethod
-	for _, method := range strings.Split(methods, ",") {
-		method = strings.ToUpper(strings.TrimSpace(method))
+	for _, method := range config.SplitConfigList(methods) {
+		method = strings.ToUpper(method)
 		switch method {
 		case "SSL":
 			result = append(result, security.AuthSSL)
@@ -593,8 +593,8 @@ func mapCryptoMethods(methods string) []security.CryptoMethod {
 	}
 
 	var result []security.CryptoMethod
-	for _, method := range strings.Split(methods, ",") {
-		method = strings.ToUpper(strings.TrimSpace(method))
+	for _, method := range config.SplitConfigList(methods) {
+		method = strings.ToUpper(method)
 		switch method {
 		case "AES":
 			result = append(result, security.CryptoAES)

--- a/security_test.go
+++ b/security_test.go
@@ -331,6 +331,12 @@ func TestMapAuthMethods(t *testing.T) {
 		{"", 0, false, false},         // empty string
 		{"SSL,KERBEROS,PASSWORD,FS", 4, true, false},
 		{"ANONYMOUS", 1, false, false}, // ANONYMOUS maps to AuthNone
+		// HTCondor lists may be whitespace-separated (StringList delimiters are
+		// comma AND space). These are real deployed values that previously
+		// collapsed to one unrecognized token and dropped to NONE.
+		{"FS TOKEN SCITOKENS SSL", 4, true, true},         // SEC_DEFAULT_AUTHENTICATION_METHODS
+		{"FS SSL PASSWORD", 3, true, false},               // TOOL.SEC_CLIENT_AUTHENTICATION_METHODS
+		{"FS SSL PASSWORD,ANONYMOUS", 4, true, false},     // mixed space + appended comma
 	}
 
 	for _, tt := range tests {
@@ -369,6 +375,9 @@ func TestMapCryptoMethods(t *testing.T) {
 		{"AES,BLOWFISH", 2, []security.CryptoMethod{security.CryptoAES, security.CryptoBlowfish}},
 		{"aes,blowfish,3des", 3, []security.CryptoMethod{security.CryptoAES, security.CryptoBlowfish, security.Crypto3DES}},
 		{"", 0, []security.CryptoMethod{}},
+		// Whitespace-separated: the real deployed SEC_DEFAULT_CRYPTO_METHODS that
+		// previously collapsed to one unrecognized token and yielded NO crypto.
+		{"AES BLOWFISH 3DES", 3, []security.CryptoMethod{security.CryptoAES, security.CryptoBlowfish, security.Crypto3DES}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Bug
A client on a real pool offered `CryptoMethods=""` (no encryption) and `AuthMethods="NONE"` (anonymous → read-only) by default, despite a valid config:
```
SEC_DEFAULT_CRYPTO_METHODS = AES BLOWFISH 3DES
SEC_DEFAULT_AUTHENTICATION_METHODS = FS TOKEN SCITOKENS SSL
TOOL.SEC_CLIENT_AUTHENTICATION_METHODS = FS SSL PASSWORD
```
HTCondor parses these as a `StringList` (delimiters: commas **and whitespace**), but `mapAuthMethods`/`mapCryptoMethods` split on commas only — so `"AES BLOWFISH 3DES"` became a single unrecognized token and was dropped.

## Fix
Reuse the repo's existing canonical splitter rather than adding a new one: export `config.splitConfigList` → `config.SplitConfigList` (already "splits on commas and/or spaces") and use it in `mapAuthMethods`, `mapCryptoMethods`, and `appendMethod`.

## Tests
`TestMapAuthMethods`/`TestMapCryptoMethods` gain the exact deployed space-separated values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)