### PR TITLE
deps: bump cedar to v0.6.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0
-	github.com/bbockelm/cedar v0.6.0
+	github.com/bbockelm/cedar v0.6.1
 	github.com/bbockelm/gosssd v0.0.1
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/PelicanPlatform/classad/collections v0.8.0 h1:qlNkYij8O52beqb0ekrYKrC
 github.com/PelicanPlatform/classad/collections v0.8.0/go.mod h1:djT/JhGuLcMnVyXOsdiniPzZC6NaxQz8ZHTkffYZtNY=
 github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5UCbeKB4UQ4=
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
-github.com/bbockelm/cedar v0.6.0 h1:RXnsqs443hDOsH2iLHHcyp/J5EIFapDVL5CPNpvbB6g=
-github.com/bbockelm/cedar v0.6.0/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.1 h1:dPC3+S49aSqrRAZgZTO/Uj7BoUgMt82uqjFqA7qmIFk=
+github.com/bbockelm/cedar v0.6.1/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=


### PR DESCRIPTION
Bumps golang-htcondor's own cedar dependency v0.6.0 → v0.6.1 so the cedar private-ad fix (SECRET_MARKER read/write + modern RemoteVersion advertisement) is carried **transitively**.

Context: cedar v0.6.1 shipped the fix, but golang-htcondor v0.8.1 still pinned cedar v0.6.0 — so every downstream consumer had to require `cedar@v0.6.1` directly to pull it (MVS). After this lands + tags (v0.8.2), a consumer that bumps only golang-htcondor gets the fix without a separate direct cedar requirement.

Build + security method-mapping tests pass with `GOWORK=off`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)