### PR TITLE
logging: force log files to 0644 regardless of umask (match C++)

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -395,6 +395,7 @@ func New(config *Config) (*Logger, error) {
 		} else {
 			logFile = f
 			writer = f
+			forceLogPerm(f)
 
 			// Get current file size for rotation tracking
 			if !config.TruncateOnOpen {
@@ -822,6 +823,7 @@ func (l *Logger) rotateLogIfNeeded() error {
 	if err != nil {
 		return fmt.Errorf("failed to create new log file: %w", err)
 	}
+	forceLogPerm(f)
 
 	// Update file handle and reset size atomically
 	l.logFile.Store(f)
@@ -886,8 +888,24 @@ func (l *Logger) PerformMaintenance() error {
 	if err := os.Chtimes(logPath, now, now); err != nil {
 		return fmt.Errorf("failed to touch log file: %w", err)
 	}
+	// Re-assert 0644 on the heartbeat, as C++ HTCondor does (dprintf.cpp): keeps the log
+	// world-readable even if the file was recreated/chmod'd out from under us.
+	//nolint:gosec // G302: daemon logs are intentionally world-readable, as in C++ HTCondor
+	_ = os.Chmod(logPath, 0644)
 
 	return nil
+}
+
+// forceLogPerm sets a freshly opened log file to 0644 regardless of the process umask,
+// matching C++ HTCondor (which chmod's its logs to 0644; see dprintf.cpp). os.OpenFile's
+// create mode is masked by umask, so a daemon under a restrictive umask (e.g. 077) would
+// otherwise get 0600 despite the 0644 argument; an explicit fchmod is not umask-subject.
+// Best-effort, like C++'s (void) chmod.
+func forceLogPerm(f *os.File) {
+	if f != nil {
+		//nolint:gosec // G302: daemon logs are intentionally world-readable, as in C++ HTCondor
+		_ = f.Chmod(0644)
+	}
 }
 
 // reopenLogFile reopens the log file after external rotation or deletion.
@@ -900,6 +918,7 @@ func (l *Logger) reopenLogFile() error {
 	if err != nil {
 		return fmt.Errorf("failed to reopen log file: %w", err)
 	}
+	forceLogPerm(f)
 
 	// Get current file size
 	stat, err := f.Stat()

--- a/logging/reconfig_test.go
+++ b/logging/reconfig_test.go
@@ -89,9 +89,12 @@ func TestParseDestinationLevels(t *testing.T) {
 }
 
 // TestLogFileMode0644 verifies daemon logs are created world-readable (matching C++
-// HTCondor), not 0600. Umask is cleared so the mode is deterministic.
+// HTCondor), not 0600 -- even under a restrictive umask. A daemon commonly inherits umask
+// 077; os.OpenFile's mode is masked by it, so without the explicit fchmod (forceLogPerm)
+// the file would come out 0600. Setting umask 077 here makes this a real regression for
+// the umask masking, not just the OpenFile mode argument.
 func TestLogFileMode0644(t *testing.T) {
-	old := syscall.Umask(0)
+	old := syscall.Umask(0o077)
 	defer syscall.Umask(old)
 
 	path := filepath.Join(t.TempDir(), "mode.log")
@@ -106,6 +109,38 @@ func TestLogFileMode0644(t *testing.T) {
 		t.Fatal(err)
 	}
 	if perm := info.Mode().Perm(); perm != 0644 {
-		t.Fatalf("log file mode = %o, want 0644", perm)
+		t.Fatalf("log file mode = %o under umask 077, want 0644 (explicit chmod should defeat umask)", perm)
+	}
+}
+
+// TestLogRotationMode0644 verifies the freshly-created log after a rotation is also 0644
+// under a restrictive umask (the rotate path recreates the file in production).
+func TestLogRotationMode0644(t *testing.T) {
+	old := syscall.Umask(0o077)
+	defer syscall.Umask(old)
+
+	path := filepath.Join(t.TempDir(), "rot.log")
+	l, err := New(&Config{
+		OutputPath:        path,
+		SkipGlobalInstall: true,
+		DefaultLevel:      VerbosityInfo,
+		MaxLogSize:        200, // tiny, so a few lines trigger rotation
+		MaxNumLogs:        2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 8; i++ {
+		l.Info(DestinationGeneral, "a message long enough to push the log past its rotation size")
+	}
+	if _, err := os.Stat(path + ".old"); err != nil {
+		t.Fatalf("expected a rotated .old log: %v", err)
+	}
+	info, err := os.Stat(path) // the post-rotation current log
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0644 {
+		t.Fatalf("post-rotation log mode = %o under umask 077, want 0644", perm)
 	}
 }


### PR DESCRIPTION
You reported golang-htcondor logs coming out `0600` vs C++ `0644`. The open mode was already `0644` (since v0.8.0), but **`os.OpenFile`'s create mode is masked by the process umask** — so a daemon inheriting a restrictive umask (e.g. `077`, common under systemd or the master) still produced `0600` logs.

C++ HTCondor guarantees `0644` with an explicit `chmod` that isn't umask-subject ([`dprintf.cpp`](https://github.com/htcondor/htcondor): `(void) chmod(logPath, 0644)`, done on its heartbeat touch). This mirrors that:

- `forceLogPerm()` `fchmod`s each freshly opened log to `0644` — at creation, rotation, and reopen.
- The maintenance heartbeat re-`chmod`s the current log to `0644`, as C++ does on its touch (defends against the file being recreated/chmodd underneath).
- The `0644` open mode stays as documentation.

**Tests** set umask `077` — the real regression, since without the explicit chmod the file is `0600` — and assert `0644` for both a newly created log and the post-rotation log. logging package builds + lints clean.

Note: this reaches production only after a tag + the collector/htcondordb `go.mod` bumps (same chain as the earlier logging fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)