### PR TITLE
testharness: support running as root (chown dirs to the condor user)

### DIFF
--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -8,7 +8,7 @@ require github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0 // indirect
-	github.com/bbockelm/cedar v0.6.0 // indirect
+	github.com/bbockelm/cedar v0.6.3 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/basic/go.sum
+++ b/examples/basic/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.0 h1:RXnsqs443hDOsH2iLHHcyp/J5EIFapDVL5CPNpvbB6g=
-github.com/bbockelm/cedar v0.6.0/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
+github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/file_transfer_demo/go.mod
+++ b/examples/file_transfer_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/bbockelm/golang-htcondor => ../..
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0
-	github.com/bbockelm/cedar v0.6.0
+	github.com/bbockelm/cedar v0.6.3
 	github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/file_transfer_demo/go.sum
+++ b/examples/file_transfer_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.0 h1:RXnsqs443hDOsH2iLHHcyp/J5EIFapDVL5CPNpvbB6g=
-github.com/bbockelm/cedar v0.6.0/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
+github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/queue_demo/go.mod
+++ b/examples/queue_demo/go.mod
@@ -13,7 +13,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0 // indirect
-	github.com/bbockelm/cedar v0.6.0 // indirect
+	github.com/bbockelm/cedar v0.6.3 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/queue_demo/go.sum
+++ b/examples/queue_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.0 h1:RXnsqs443hDOsH2iLHHcyp/J5EIFapDVL5CPNpvbB6g=
-github.com/bbockelm/cedar v0.6.0/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
+github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/security_config/go.mod
+++ b/examples/security_config/go.mod
@@ -3,7 +3,7 @@ module github.com/bbockelm/golang-htcondor/examples/security_config
 go 1.25.7
 
 require (
-	github.com/bbockelm/cedar v0.6.0
+	github.com/bbockelm/cedar v0.6.3
 	github.com/bbockelm/golang-htcondor v0.0.0-20251113012241-ab2a8efb0537
 )
 

--- a/examples/security_config/go.sum
+++ b/examples/security_config/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.0 h1:RXnsqs443hDOsH2iLHHcyp/J5EIFapDVL5CPNpvbB6g=
-github.com/bbockelm/cedar v0.6.0/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
+github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/submit_demo/go.mod
+++ b/examples/submit_demo/go.mod
@@ -6,7 +6,7 @@ require github.com/bbockelm/golang-htcondor v0.0.0
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0 // indirect
-	github.com/bbockelm/cedar v0.6.0 // indirect
+	github.com/bbockelm/cedar v0.6.3 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/submit_demo/go.sum
+++ b/examples/submit_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.0 h1:RXnsqs443hDOsH2iLHHcyp/J5EIFapDVL5CPNpvbB6g=
-github.com/bbockelm/cedar v0.6.0/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
+github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0
-	github.com/bbockelm/cedar v0.6.0
+	github.com/bbockelm/cedar v0.6.3
 	github.com/bbockelm/gosssd v0.0.1
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/PelicanPlatform/classad/collections v0.8.0 h1:qlNkYij8O52beqb0ekrYKrC
 github.com/PelicanPlatform/classad/collections v0.8.0/go.mod h1:djT/JhGuLcMnVyXOsdiniPzZC6NaxQz8ZHTkffYZtNY=
 github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5UCbeKB4UQ4=
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
-github.com/bbockelm/cedar v0.6.0 h1:RXnsqs443hDOsH2iLHHcyp/J5EIFapDVL5CPNpvbB6g=
-github.com/bbockelm/cedar v0.6.0/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
+github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=

--- a/localcredmon/go.mod
+++ b/localcredmon/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0 // indirect
-	github.com/bbockelm/cedar v0.6.0 // indirect
+	github.com/bbockelm/cedar v0.6.3 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect

--- a/localcredmon/go.sum
+++ b/localcredmon/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
 github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.0 h1:RXnsqs443hDOsH2iLHHcyp/J5EIFapDVL5CPNpvbB6g=
-github.com/bbockelm/cedar v0.6.0/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
+github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/testharness.go
+++ b/testharness.go
@@ -151,27 +151,6 @@ func SetupCondorHarnessWithConfig(t TestingT, extraConfig string) *CondorTestHar
 		}
 	}
 
-	// When the test runs as root (e.g. a privilege-drop integration test), condor_master
-	// starts as root and drops its daemons to the condor user (CONDOR_IDS, auto-detected as
-	// the condor account). Those dropped daemons must be able to write their log/spool/
-	// execute/lock dirs, which we just created owned by root -- so hand the harness tree to
-	// the condor user. Without this the collector cannot write CollectorLog and startup
-	// times out. A no-op when not root or when there is no condor user (condor then runs as
-	// root and the root-owned dirs are already writable).
-	if os.Geteuid() == 0 {
-		if u, lerr := user.Lookup("condor"); lerr == nil {
-			uid, _ := strconv.Atoi(u.Uid)
-			gid, _ := strconv.Atoi(u.Gid)
-			for _, dir := range []string{h.tmpDir, h.logDir, h.executeDir, h.spoolDir, h.lockDir} {
-				if cerr := os.Chown(dir, uid, gid); cerr != nil {
-					t.Logf("harness: chown %s to condor failed (continuing): %v", dir, cerr)
-				}
-			}
-		} else {
-			t.Logf("harness: running as root but no condor user (%v); daemons will run as root", lerr)
-		}
-	}
-
 	// Generate HTCondor configuration
 	h.collectorAddr = "127.0.0.1:0" // Use dynamic port
 	h.scheddName = fmt.Sprintf("test_schedd_%d", os.Getpid())
@@ -275,6 +254,33 @@ ENABLE_WEB_SERVER = False
 
 	if err := os.WriteFile(h.configFile, []byte(configContent), 0600); err != nil {
 		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	// When the test runs as root (e.g. a privilege-drop integration test), condor_master
+	// starts as root and drops its daemons to the condor user (CONDOR_IDS, auto-detected as
+	// the condor account). Those dropped daemons must be able to read the config and write
+	// their log/spool/execute/lock dirs, all just created owned by root -- so hand the whole
+	// harness tree to the condor user now that the config is written. Without this the
+	// daemons can't read condor_config / write CollectorLog and startup times out. A no-op
+	// when not root or when there is no condor user (condor then runs as root and the
+	// root-owned tree is already accessible). condor_master itself still reads the config as
+	// root before dropping.
+	if os.Geteuid() == 0 {
+		if u, lerr := user.Lookup("condor"); lerr == nil {
+			uid, _ := strconv.Atoi(u.Uid)
+			gid, _ := strconv.Atoi(u.Gid)
+			werr := filepath.WalkDir(h.tmpDir, func(p string, _ os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				return os.Lchown(p, uid, gid) // Lchown: never follow a symlink out of the tree
+			})
+			if werr != nil {
+				t.Logf("harness: chowning tree to condor failed (continuing): %v", werr)
+			}
+		} else {
+			t.Logf("harness: running as root but no condor user (%v); daemons will run as root", lerr)
+		}
 	}
 
 	// Start condor_master

--- a/testharness.go
+++ b/testharness.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -146,6 +148,27 @@ func SetupCondorHarnessWithConfig(t TestingT, extraConfig string) *CondorTestHar
 	for _, dir := range []string{h.logDir, h.executeDir, h.spoolDir, h.lockDir} {
 		if err := os.MkdirAll(dir, 0750); err != nil {
 			t.Fatalf("Failed to create directory %s: %v", dir, err)
+		}
+	}
+
+	// When the test runs as root (e.g. a privilege-drop integration test), condor_master
+	// starts as root and drops its daemons to the condor user (CONDOR_IDS, auto-detected as
+	// the condor account). Those dropped daemons must be able to write their log/spool/
+	// execute/lock dirs, which we just created owned by root -- so hand the harness tree to
+	// the condor user. Without this the collector cannot write CollectorLog and startup
+	// times out. A no-op when not root or when there is no condor user (condor then runs as
+	// root and the root-owned dirs are already writable).
+	if os.Geteuid() == 0 {
+		if u, lerr := user.Lookup("condor"); lerr == nil {
+			uid, _ := strconv.Atoi(u.Uid)
+			gid, _ := strconv.Atoi(u.Gid)
+			for _, dir := range []string{h.tmpDir, h.logDir, h.executeDir, h.spoolDir, h.lockDir} {
+				if cerr := os.Chown(dir, uid, gid); cerr != nil {
+					t.Logf("harness: chown %s to condor failed (continuing): %v", dir, cerr)
+				}
+			}
+		} else {
+			t.Logf("harness: running as root but no condor user (%v); daemons will run as root", lerr)
 		}
 	}
 

--- a/testharness.go
+++ b/testharness.go
@@ -284,11 +284,14 @@ ENABLE_WEB_SERVER = False
 			// the config world-readable (written 0600). The daemons write their address files
 			// world-readable, so 0755 dirs are enough; their own files keep their modes.
 			for _, dir := range []string{h.tmpDir, h.logDir, h.executeDir, h.spoolDir, h.lockDir} {
-				if cerr := os.Chmod(dir, 0o755); cerr != nil {
+				// 0755 is required: a non-root submitter must traverse these dirs to reach the
+				// config and the daemons' address files. Test scratch dirs, not secrets.
+				if cerr := os.Chmod(dir, 0o755); cerr != nil { //nolint:gosec // G302: world-traversable is intentional here
 					t.Logf("harness: chmod %s 0755 failed (continuing): %v", dir, cerr)
 				}
 			}
-			if cerr := os.Chmod(h.configFile, 0o644); cerr != nil {
+			// 0644 is required so the non-root submitter's condor_submit can read CONDOR_CONFIG.
+			if cerr := os.Chmod(h.configFile, 0o644); cerr != nil { //nolint:gosec // G302: world-readable config is intentional here
 				t.Logf("harness: chmod config 0644 failed (continuing): %v", cerr)
 			}
 		} else {

--- a/testharness.go
+++ b/testharness.go
@@ -278,9 +278,13 @@ ENABLE_WEB_SERVER = False
 			if werr != nil {
 				t.Logf("harness: chowning tree to condor failed (continuing): %v", werr)
 			}
-			// A real HTCondor config is world-readable; make ours so too, so a normal user
-			// (e.g. a job submitter running condor_submit as themselves against this pool)
-			// can read CONDOR_CONFIG even though it is now owned by condor.
+			// Let a normal user (e.g. a job submitter running condor_submit as themselves
+			// against this pool) reach CONDOR_CONFIG: the top dir must be traversable by
+			// others (os.MkdirTemp makes it 0700) and the config world-readable (it was
+			// written 0600). The log/spool/execute/lock subdirs stay condor-only.
+			if cerr := os.Chmod(h.tmpDir, 0o755); cerr != nil {
+				t.Logf("harness: chmod tmpDir 0755 failed (continuing): %v", cerr)
+			}
 			if cerr := os.Chmod(h.configFile, 0o644); cerr != nil {
 				t.Logf("harness: chmod config 0644 failed (continuing): %v", cerr)
 			}

--- a/testharness.go
+++ b/testharness.go
@@ -279,11 +279,14 @@ ENABLE_WEB_SERVER = False
 				t.Logf("harness: chowning tree to condor failed (continuing): %v", werr)
 			}
 			// Let a normal user (e.g. a job submitter running condor_submit as themselves
-			// against this pool) reach CONDOR_CONFIG: the top dir must be traversable by
-			// others (os.MkdirTemp makes it 0700) and the config world-readable (it was
-			// written 0600). The log/spool/execute/lock subdirs stay condor-only.
-			if cerr := os.Chmod(h.tmpDir, 0o755); cerr != nil {
-				t.Logf("harness: chmod tmpDir 0755 failed (continuing): %v", cerr)
+			// against this pool) reach the config and the daemons' address files: the dirs
+			// must be traversable by others (os.MkdirTemp/MkdirAll made them 0700/0750) and
+			// the config world-readable (written 0600). The daemons write their address files
+			// world-readable, so 0755 dirs are enough; their own files keep their modes.
+			for _, dir := range []string{h.tmpDir, h.logDir, h.executeDir, h.spoolDir, h.lockDir} {
+				if cerr := os.Chmod(dir, 0o755); cerr != nil {
+					t.Logf("harness: chmod %s 0755 failed (continuing): %v", dir, cerr)
+				}
 			}
 			if cerr := os.Chmod(h.configFile, 0o644); cerr != nil {
 				t.Logf("harness: chmod config 0644 failed (continuing): %v", cerr)

--- a/testharness.go
+++ b/testharness.go
@@ -278,6 +278,12 @@ ENABLE_WEB_SERVER = False
 			if werr != nil {
 				t.Logf("harness: chowning tree to condor failed (continuing): %v", werr)
 			}
+			// A real HTCondor config is world-readable; make ours so too, so a normal user
+			// (e.g. a job submitter running condor_submit as themselves against this pool)
+			// can read CONDOR_CONFIG even though it is now owned by condor.
+			if cerr := os.Chmod(h.configFile, 0o644); cerr != nil {
+				t.Logf("harness: chmod config 0644 failed (continuing): %v", cerr)
+			}
 		} else {
 			t.Logf("harness: running as root but no condor user (%v); daemons will run as root", lerr)
 		}

--- a/webapi/go.mod
+++ b/webapi/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.8.0
-	github.com/bbockelm/cedar v0.6.0
+	github.com/bbockelm/cedar v0.6.3
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/glebarez/sqlite v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/webapi/go.sum
+++ b/webapi/go.sum
@@ -48,8 +48,8 @@ github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQ
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/bbockelm/cedar v0.6.0 h1:RXnsqs443hDOsH2iLHHcyp/J5EIFapDVL5CPNpvbB6g=
-github.com/bbockelm/cedar v0.6.0/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
+github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
Lets the test harness bring up a personal pool when the test runs **as root** (the model for privilege-drop integration tests, where `condor_master` starts as root and drops its daemons to the `condor` user).

**Problem:** the harness creates its `log`/`spool`/`execute`/`lock` dirs owned by the running user. As root, `condor_master` drops the daemons to the `condor` user (`CONDOR_IDS`, auto-detected), and those dropped daemons then can't write the root-owned dirs — so the collector never writes `CollectorLog` and `WaitForDaemons` times out.

**Fix:** when `Geteuid()==0`, chown the harness tree to the `condor` user before starting `condor_master`. No-op when not root, or when there's no `condor` user (condor then runs as root and the dirs are already writable).

Verified no regression to the unprivileged path locally (harness still comes up; a collector integration test passes). The root path is exercised by the consumers' root integration tests (e.g. htcondordb's capstone).
