### PR TITLE
daemon: default-on session-cache persistence, no per-binary wiring

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -37,6 +37,12 @@ type Options struct {
 	// names the address file (<Subsys>_ADDRESS_FILE).
 	Subsys string
 
+	// LocalName is the daemon's HTCondor local-name (-local-name), when running
+	// as a named instance of the subsystem. It scopes the default session-
+	// database file name (see SessionDBFileName), so several instances sharing
+	// a SPOOL keep separate session caches.
+	LocalName string
+
 	// Config is the HTCondor configuration. If nil, it is loaded from
 	// CONDOR_CONFIG.
 	Config *config.Config
@@ -53,7 +59,8 @@ type Options struct {
 // Daemon is an HTCondor daemon bootstrap. It is safe to construct once and use
 // from a single Run/Serve call.
 type Daemon struct {
-	subsys string
+	subsys    string
+	localName string
 	// cfg is swapped atomically on SIGHUP reconfigure; readers (Config) load it
 	// without locking, so a reconfigure never races a concurrent reader.
 	cfg   atomic.Pointer[config.Config]
@@ -124,6 +131,7 @@ func New(opts Options) (*Daemon, error) {
 
 	d := &Daemon{
 		subsys:     opts.Subsys,
+		localName:  opts.LocalName,
 		log:        logger,
 		grace:      grace,
 		shutdownCh: make(chan struct{}),
@@ -284,6 +292,18 @@ func (d *Daemon) ServeListeners(ctx context.Context, serve func(context.Context,
 	if len(lns) == 0 {
 		return fmt.Errorf("daemon: ServeListeners requires at least one listener")
 	}
+
+	// Default-on session persistence: restore/persist the CEDAR session cache
+	// without any per-binary wiring (see autoSessionPersistence). Runs before
+	// the serve loops so the first request can already resume a session.
+	closeSessions, err := d.autoSessionPersistence()
+	if err != nil {
+		return err
+	}
+	if closeSessions != nil {
+		defer closeSessions()
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -293,10 +293,11 @@ func (d *Daemon) ServeListeners(ctx context.Context, serve func(context.Context,
 		return fmt.Errorf("daemon: ServeListeners requires at least one listener")
 	}
 
-	// Default-on session persistence: restore/persist the CEDAR session cache
-	// without any per-binary wiring (see autoSessionPersistence). Runs before
-	// the serve loops so the first request can already resume a session.
-	closeSessions, err := d.autoSessionPersistence()
+	// Single-knob session persistence (SEC_PERSIST_SESSIONS, default off):
+	// restore/persist the CEDAR session cache without any per-binary wiring (see
+	// sessionPersistenceFromConfig). Runs before the serve loops so the first
+	// request can already resume a session.
+	closeSessions, err := d.sessionPersistenceFromConfig()
 	if err != nil {
 		return err
 	}

--- a/daemon/sessionauto_test.go
+++ b/daemon/sessionauto_test.go
@@ -1,0 +1,83 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bbockelm/golang-htcondor/config"
+)
+
+// TestSessionDBFileName pins the naming convention: the shared "sessions_"
+// prefix lets administrators exclude every daemon's session database from
+// spool cleanup with one glob (VALID_SPOOL_FILES = sessions_*), while the
+// subsystem + local-name keep instances sharing a SPOOL from opening each
+// other's databases.
+func TestSessionDBFileName(t *testing.T) {
+	cases := []struct{ subsys, local, want string }{
+		{"COLLECTOR", "", "sessions_collector.db"},
+		{"COLLECTOR", "ViewServer", "sessions_collector_viewserver.db"},
+		{"HTCONDORDB", "JobsDB", "sessions_htcondordb_jobsdb.db"},
+	}
+	for _, tc := range cases {
+		if got := SessionDBFileName(tc.subsys, tc.local); got != tc.want {
+			t.Errorf("SessionDBFileName(%q,%q) = %q, want %q", tc.subsys, tc.local, got, tc.want)
+		}
+	}
+}
+
+func autoTestDaemon(t *testing.T, confText string) *Daemon {
+	t.Helper()
+	cfg, err := config.NewFromReader(strings.NewReader(confText))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := New(Options{Subsys: "TESTDAEMON", LocalName: "auto", Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// TestAutoSessionPersistence covers the default-on policy matrix.
+func TestAutoSessionPersistence(t *testing.T) {
+	// Explicitly off: nothing happens.
+	d := autoTestDaemon(t, "TESTDAEMON_PERSIST_SESSIONS = false\n")
+	if closer, err := d.autoSessionPersistence(); err != nil || closer != nil {
+		t.Fatalf("explicit false: got closer=%v err=%v, want nil/nil", closer != nil, err)
+	}
+
+	// AUTO with no SPOOL and no keys: skips quietly.
+	d = autoTestDaemon(t, "")
+	if closer, err := d.autoSessionPersistence(); err != nil || closer != nil {
+		t.Fatalf("auto without prerequisites: got closer=%v err=%v, want nil/nil (skip)", closer != nil, err)
+	}
+
+	// Explicitly required without signing keys: fatal, never plaintext.
+	spool := t.TempDir()
+	d = autoTestDaemon(t, "TESTDAEMON_PERSIST_SESSIONS = true\nSPOOL = "+spool+"\n")
+	if _, err := d.autoSessionPersistence(); err == nil {
+		t.Fatal("required without signing keys succeeded; must be a fatal misconfiguration")
+	}
+
+	// AUTO with SPOOL + a signing key: enabled, database created under the
+	// prefix-named default, closer returned.
+	keydir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(keydir, "POOL"), []byte("test-signing-key-material"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d = autoTestDaemon(t, "SPOOL = "+spool+"\nSEC_PASSWORD_DIRECTORY = "+keydir+"\n")
+	closer, err := d.autoSessionPersistence()
+	if err != nil {
+		t.Fatalf("auto with prerequisites: %v", err)
+	}
+	if closer == nil {
+		t.Fatal("auto with prerequisites returned no closer (not enabled?)")
+	}
+	defer closer()
+	want := filepath.Join(spool, "sessions_testdaemon_auto.db")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("session database not created at %s: %v", want, err)
+	}
+}

--- a/daemon/sessionauto_test.go
+++ b/daemon/sessionauto_test.go
@@ -40,44 +40,66 @@ func autoTestDaemon(t *testing.T, confText string) *Daemon {
 	return d
 }
 
-// TestAutoSessionPersistence covers the default-on policy matrix.
-func TestAutoSessionPersistence(t *testing.T) {
-	// Explicitly off: nothing happens.
-	d := autoTestDaemon(t, "TESTDAEMON_PERSIST_SESSIONS = false\n")
-	if closer, err := d.autoSessionPersistence(); err != nil || closer != nil {
-		t.Fatalf("explicit false: got closer=%v err=%v, want nil/nil", closer != nil, err)
-	}
-
-	// AUTO with no SPOOL and no keys: skips quietly.
-	d = autoTestDaemon(t, "")
-	if closer, err := d.autoSessionPersistence(); err != nil || closer != nil {
-		t.Fatalf("auto without prerequisites: got closer=%v err=%v, want nil/nil (skip)", closer != nil, err)
-	}
-
-	// Explicitly required without signing keys: fatal, never plaintext.
+// TestSessionPersistenceFromConfig covers the single-knob policy matrix:
+// SEC_PERSIST_SESSIONS defaults OFF; when set, missing prerequisites are fatal.
+func TestSessionPersistenceFromConfig(t *testing.T) {
+	// Knob unset: default off, nothing happens even with prerequisites present.
 	spool := t.TempDir()
-	d = autoTestDaemon(t, "TESTDAEMON_PERSIST_SESSIONS = true\nSPOOL = "+spool+"\n")
-	if _, err := d.autoSessionPersistence(); err == nil {
-		t.Fatal("required without signing keys succeeded; must be a fatal misconfiguration")
-	}
-
-	// AUTO with SPOOL + a signing key: enabled, database created under the
-	// prefix-named default, closer returned.
 	keydir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(keydir, "POOL"), []byte("test-signing-key-material"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	d = autoTestDaemon(t, "SPOOL = "+spool+"\nSEC_PASSWORD_DIRECTORY = "+keydir+"\n")
-	closer, err := d.autoSessionPersistence()
+	d := autoTestDaemon(t, "SPOOL = "+spool+"\nSEC_PASSWORD_DIRECTORY = "+keydir+"\n")
+	if closer, err := d.sessionPersistenceFromConfig(); err != nil || closer != nil {
+		t.Fatalf("knob unset: got closer=%v err=%v, want nil/nil (default off)", closer != nil, err)
+	}
+
+	// Explicitly off: same.
+	d = autoTestDaemon(t, "SEC_PERSIST_SESSIONS = false\nSPOOL = "+spool+"\n")
+	if closer, err := d.sessionPersistenceFromConfig(); err != nil || closer != nil {
+		t.Fatalf("explicit false: got closer=%v err=%v, want nil/nil", closer != nil, err)
+	}
+
+	// Enabled without SPOOL: fatal misconfiguration, not a quiet skip.
+	d = autoTestDaemon(t, "SEC_PERSIST_SESSIONS = true\n")
+	if _, err := d.sessionPersistenceFromConfig(); err == nil {
+		t.Fatal("enabled without SPOOL succeeded; must be fatal")
+	}
+
+	// Enabled without signing keys: fatal, never plaintext.
+	d = autoTestDaemon(t, "SEC_PERSIST_SESSIONS = true\nSPOOL = "+spool+"\n")
+	if _, err := d.sessionPersistenceFromConfig(); err == nil {
+		t.Fatal("enabled without signing keys succeeded; must be fatal")
+	}
+
+	// Enabled with SPOOL + a signing key: database created under the
+	// prefix-named default, closer returned.
+	d = autoTestDaemon(t, "SEC_PERSIST_SESSIONS = true\nSPOOL = "+spool+"\nSEC_PASSWORD_DIRECTORY = "+keydir+"\n")
+	closer, err := d.sessionPersistenceFromConfig()
 	if err != nil {
-		t.Fatalf("auto with prerequisites: %v", err)
+		t.Fatalf("enabled with prerequisites: %v", err)
 	}
 	if closer == nil {
-		t.Fatal("auto with prerequisites returned no closer (not enabled?)")
+		t.Fatal("enabled with prerequisites returned no closer (not enabled?)")
 	}
-	defer closer()
+	closer()
 	want := filepath.Join(spool, "sessions_testdaemon_auto.db")
 	if _, err := os.Stat(want); err != nil {
 		t.Fatalf("session database not created at %s: %v", want, err)
+	}
+
+	// SEC_SESSION_CACHE_FILE overrides the SPOOL-derived path entirely.
+	override := filepath.Join(t.TempDir(), "my_sessions.db")
+	d = autoTestDaemon(t, "SEC_PERSIST_SESSIONS = true\nSEC_SESSION_CACHE_FILE = "+override+"\nSEC_PASSWORD_DIRECTORY = "+keydir+"\n")
+	closer, err = d.sessionPersistenceFromConfig()
+	if err != nil {
+		t.Fatalf("override path: %v", err)
+	}
+	if closer == nil {
+		t.Fatal("override path returned no closer")
+	}
+	closer()
+	if _, err := os.Stat(override); err != nil {
+		t.Fatalf("session database not created at override path %s: %v", override, err)
 	}
 }

--- a/daemon/sessioncache.go
+++ b/daemon/sessioncache.go
@@ -101,56 +101,48 @@ func SessionDBFileName(subsys, localName string) string {
 	return name + ".db"
 }
 
-// autoSessionPersistence is the zero-wiring default every daemon gets from
-// Serve: persist the CEDAR session cache whenever the deployment makes that
-// possible, so clients resume sessions across a restart instead of landing on
-// SID_NOT_FOUND and re-authenticating in a thundering herd.
+// sessionPersistenceFromConfig is the single-knob session-persistence policy
+// every daemon gets from Serve, with no per-binary wiring:
 //
-// Policy, per the <SUBSYS>_PERSIST_SESSIONS knob:
-//   - unset (the default): AUTO -- enable when SPOOL is configured and pool
-//     signing keys are available (they encrypt the database at rest); log and
-//     continue unpersisted when either is missing.
-//   - false: off.
-//   - true: required -- a missing prerequisite is a fatal misconfiguration,
-//     never a silent fallback (in particular, never a plaintext session store).
+//	SEC_PERSIST_SESSIONS = true
 //
-// <SUBSYS>_SESSION_CACHE_FILE overrides the default
-// $(SPOOL)/SessionDBFileName(...) path; <SUBSYS>_SESSION_SNAPSHOT_INTERVAL
-// (seconds) the snapshot cadence. A binary that already called
+// turns on persistence of the CEDAR session cache (default OFF), so clients
+// resume sessions across this daemon's restarts instead of landing on
+// SID_NOT_FOUND and re-authenticating in a thundering herd. One unified knob
+// covers every daemon; HTCondor's standard subsystem scoping
+// (<SUBSYS>.SEC_PERSIST_SESSIONS) narrows it to one daemon when desired.
+//
+// When enabled, a missing prerequisite is a fatal misconfiguration, never a
+// quiet skip: SPOOL (or SEC_SESSION_CACHE_FILE) must be configured, and pool
+// signing keys must be available -- they encrypt the database at rest (read as
+// root via droppriv), so there is no plaintext fallback.
+// SEC_SESSION_CACHE_FILE overrides the default $(SPOOL)/SessionDBFileName(...)
+// path and SEC_SESSION_SNAPSHOT_INTERVAL (seconds) the snapshot cadence; both
+// scope per-subsystem the same way. A binary that already called
 // EnableSessionPersistence itself keeps its own arrangement (this is a no-op).
 // Returns a closer for the store (nil when not enabled).
-func (d *Daemon) autoSessionPersistence() (func(), error) {
+func (d *Daemon) sessionPersistenceFromConfig() (func(), error) {
 	if d.sessionStore != nil {
 		return nil, nil // the binary wired persistence itself
 	}
 	cfg := d.Config()
 
-	required := false
-	if v, ok := cfg.Get(d.subsys + "_PERSIST_SESSIONS"); ok && strings.TrimSpace(v) != "" {
-		on := configTruthy(v)
-		if !on {
-			return nil, nil
-		}
-		required = true
+	v, ok := cfg.Get("SEC_PERSIST_SESSIONS")
+	if !ok || !configTruthy(v) {
+		return nil, nil // default off
 	}
-	// skip: in AUTO mode a missing prerequisite just logs; when the knob demands
-	// persistence it is fatal.
-	skip := func(format string, args ...any) (func(), error) {
-		if required {
-			return nil, fmt.Errorf("daemon: "+d.subsys+"_PERSIST_SESSIONS is set but "+format, args...)
-		}
-		d.log.Info(logging.DestinationGeneral, "session persistence not enabled: "+fmt.Sprintf(format, args...))
-		return nil, nil
+	fail := func(format string, args ...any) (func(), error) {
+		return nil, fmt.Errorf("daemon: SEC_PERSIST_SESSIONS is set but "+format, args...)
 	}
 
 	dbPath := ""
-	if v, ok := cfg.Get(d.subsys + "_SESSION_CACHE_FILE"); ok {
+	if v, ok := cfg.Get("SEC_SESSION_CACHE_FILE"); ok {
 		dbPath = strings.TrimSpace(v)
 	}
 	if dbPath == "" {
 		spool, ok := cfg.Get("SPOOL")
 		if !ok || strings.TrimSpace(spool) == "" {
-			return skip("no SPOOL (nor %s_SESSION_CACHE_FILE) is configured", d.subsys)
+			return fail("no SPOOL (nor SEC_SESSION_CACHE_FILE) is configured")
 		}
 		dbPath = filepath.Join(strings.TrimSpace(spool), SessionDBFileName(d.subsys, d.localName))
 	}
@@ -159,10 +151,10 @@ func (d *Daemon) autoSessionPersistence() (func(), error) {
 	// 0600 files read back as root via droppriv.
 	rawKeys, err := htcondor.LoadSigningKeys(cfg)
 	if err != nil {
-		return skip("loading pool signing keys failed: %v", err)
+		return fail("loading pool signing keys failed: %v", err)
 	}
 	if len(rawKeys) == 0 {
-		return skip("no pool signing keys are available (set SEC_PASSWORD_DIRECTORY); the session database cannot be encrypted without one")
+		return fail("no pool signing keys are available (set SEC_PASSWORD_DIRECTORY); the session database cannot be encrypted without one")
 	}
 	keys := make([]sqlite.SigningKey, 0, len(rawKeys))
 	for id, material := range rawKeys {
@@ -171,18 +163,18 @@ func (d *Daemon) autoSessionPersistence() (func(), error) {
 
 	store, err := sqlite.Open(dbPath, keys, d.Slog())
 	if err != nil {
-		return skip("opening %s failed: %v", dbPath, err)
+		return fail("opening %s failed: %v", dbPath, err)
 	}
 
 	interval := time.Duration(0)
-	if v, ok := cfg.Get(d.subsys + "_SESSION_SNAPSHOT_INTERVAL"); ok {
+	if v, ok := cfg.Get("SEC_SESSION_SNAPSHOT_INTERVAL"); ok {
 		if secs, perr := strconv.Atoi(strings.TrimSpace(v)); perr == nil && secs > 0 {
 			interval = time.Duration(secs) * time.Second
 		}
 	}
 	if err := d.EnableSessionPersistence(store, interval); err != nil {
 		_ = store.Close()
-		return skip("restoring persisted sessions from %s failed: %v", dbPath, err)
+		return fail("restoring persisted sessions from %s failed: %v", dbPath, err)
 	}
 	d.log.Info(logging.DestinationGeneral, "session persistence enabled",
 		"path", dbPath, "signing_keys", len(keys))

--- a/daemon/sessioncache.go
+++ b/daemon/sessioncache.go
@@ -2,11 +2,17 @@ package daemon
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bbockelm/cedar/security"
+	htcondor "github.com/bbockelm/golang-htcondor"
 	"github.com/bbockelm/golang-htcondor/logging"
 	"github.com/bbockelm/golang-htcondor/sessioncache"
+	"github.com/bbockelm/golang-htcondor/sessioncache/sqlite"
 )
 
 // defaultSessionSnapshotInterval is how often the session cache is persisted
@@ -78,4 +84,116 @@ func (d *Daemon) finalSessionSnapshot() {
 func (d *Daemon) snapshotSessions(ctx context.Context) error {
 	recs := sessioncache.Snapshot(security.GetSessionCache())
 	return d.sessionStore.Save(ctx, recs)
+}
+
+// SessionDBFileName is the default session-database file name for a daemon:
+// "sessions_<subsystem>[_<local-name>].db", lower-cased. The common "sessions_"
+// PREFIX gives administrators one glob for every daemon's session database --
+// e.g. a VALID_SPOOL_FILES exclusion of "sessions_*" -- while the subsystem
+// (plus any local-name) keeps the name per-daemon: several daemons, or several
+// instances of one under distinct local-names, may share a SPOOL, and two
+// daemons writing one session database would corrupt each other's caches.
+func SessionDBFileName(subsys, localName string) string {
+	name := "sessions_" + strings.ToLower(subsys)
+	if localName != "" {
+		name += "_" + strings.ToLower(localName)
+	}
+	return name + ".db"
+}
+
+// autoSessionPersistence is the zero-wiring default every daemon gets from
+// Serve: persist the CEDAR session cache whenever the deployment makes that
+// possible, so clients resume sessions across a restart instead of landing on
+// SID_NOT_FOUND and re-authenticating in a thundering herd.
+//
+// Policy, per the <SUBSYS>_PERSIST_SESSIONS knob:
+//   - unset (the default): AUTO -- enable when SPOOL is configured and pool
+//     signing keys are available (they encrypt the database at rest); log and
+//     continue unpersisted when either is missing.
+//   - false: off.
+//   - true: required -- a missing prerequisite is a fatal misconfiguration,
+//     never a silent fallback (in particular, never a plaintext session store).
+//
+// <SUBSYS>_SESSION_CACHE_FILE overrides the default
+// $(SPOOL)/SessionDBFileName(...) path; <SUBSYS>_SESSION_SNAPSHOT_INTERVAL
+// (seconds) the snapshot cadence. A binary that already called
+// EnableSessionPersistence itself keeps its own arrangement (this is a no-op).
+// Returns a closer for the store (nil when not enabled).
+func (d *Daemon) autoSessionPersistence() (func(), error) {
+	if d.sessionStore != nil {
+		return nil, nil // the binary wired persistence itself
+	}
+	cfg := d.Config()
+
+	required := false
+	if v, ok := cfg.Get(d.subsys + "_PERSIST_SESSIONS"); ok && strings.TrimSpace(v) != "" {
+		on := configTruthy(v)
+		if !on {
+			return nil, nil
+		}
+		required = true
+	}
+	// skip: in AUTO mode a missing prerequisite just logs; when the knob demands
+	// persistence it is fatal.
+	skip := func(format string, args ...any) (func(), error) {
+		if required {
+			return nil, fmt.Errorf("daemon: "+d.subsys+"_PERSIST_SESSIONS is set but "+format, args...)
+		}
+		d.log.Info(logging.DestinationGeneral, "session persistence not enabled: "+fmt.Sprintf(format, args...))
+		return nil, nil
+	}
+
+	dbPath := ""
+	if v, ok := cfg.Get(d.subsys + "_SESSION_CACHE_FILE"); ok {
+		dbPath = strings.TrimSpace(v)
+	}
+	if dbPath == "" {
+		spool, ok := cfg.Get("SPOOL")
+		if !ok || strings.TrimSpace(spool) == "" {
+			return skip("no SPOOL (nor %s_SESSION_CACHE_FILE) is configured", d.subsys)
+		}
+		dbPath = filepath.Join(strings.TrimSpace(spool), SessionDBFileName(d.subsys, d.localName))
+	}
+
+	// The pool signing key(s) encrypt the database at rest; they are root-owned
+	// 0600 files read back as root via droppriv.
+	rawKeys, err := htcondor.LoadSigningKeys(cfg)
+	if err != nil {
+		return skip("loading pool signing keys failed: %v", err)
+	}
+	if len(rawKeys) == 0 {
+		return skip("no pool signing keys are available (set SEC_PASSWORD_DIRECTORY); the session database cannot be encrypted without one")
+	}
+	keys := make([]sqlite.SigningKey, 0, len(rawKeys))
+	for id, material := range rawKeys {
+		keys = append(keys, sqlite.SigningKey{ID: id, Material: material})
+	}
+
+	store, err := sqlite.Open(dbPath, keys, d.Slog())
+	if err != nil {
+		return skip("opening %s failed: %v", dbPath, err)
+	}
+
+	interval := time.Duration(0)
+	if v, ok := cfg.Get(d.subsys + "_SESSION_SNAPSHOT_INTERVAL"); ok {
+		if secs, perr := strconv.Atoi(strings.TrimSpace(v)); perr == nil && secs > 0 {
+			interval = time.Duration(secs) * time.Second
+		}
+	}
+	if err := d.EnableSessionPersistence(store, interval); err != nil {
+		_ = store.Close()
+		return skip("restoring persisted sessions from %s failed: %v", dbPath, err)
+	}
+	d.log.Info(logging.DestinationGeneral, "session persistence enabled",
+		"path", dbPath, "signing_keys", len(keys))
+	return func() { _ = store.Close() }, nil
+}
+
+// configTruthy interprets an HTCondor boolean knob value.
+func configTruthy(v string) bool {
+	switch strings.ToUpper(strings.TrimSpace(v)) {
+	case "TRUE", "YES", "1", "T", "ON":
+		return true
+	}
+	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad/collections v0.8.0
+	github.com/glebarez/go-sqlite v1.21.2
 	github.com/pressly/goose/v3 v3.27.2
 )
 
@@ -53,5 +54,5 @@ require (
 	modernc.org/libc v1.74.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	modernc.org/sqlite v1.54.0
+	modernc.org/sqlite v1.54.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/glebarez/go-sqlite v1.21.2 h1:3a6LFC4sKahUunAmynQKLZceZCOzUthkRkEAl9gAXWo=
+github.com/glebarez/go-sqlite v1.21.2/go.mod h1:sfxdZyhQjTM2Wry3gVYWaW072Ri1WMdWJi0k6+3382k=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/sessioncache/sqlite/store.go
+++ b/sessioncache/sqlite/store.go
@@ -18,7 +18,12 @@ import (
 
 	"github.com/bbockelm/golang-htcondor/sessioncache"
 	"github.com/pressly/goose/v3"
-	_ "modernc.org/sqlite" // registers the pure-Go "sqlite" database/sql driver
+	// glebarez/go-sqlite is the modernc.org/sqlite-derived pure-Go engine that
+	// registers the "sqlite" database/sql driver. We use it (rather than modernc
+	// directly) because the webapi module's GORM driver links glebarez too --
+	// linking both libraries into one binary panics at init with
+	// "sql: Register called twice for driver sqlite".
+	_ "github.com/glebarez/go-sqlite"
 )
 
 //go:embed migrations/*.sql


### PR DESCRIPTION
Adds daemon-level session persistence behind a **single unified knob, default off**:

```
SEC_PERSIST_SESSIONS = true
```

- One knob covers every daemon built on the `daemon` package — no per-binary wiring. HTCondor's standard subsystem scoping (`<SUBSYS>.SEC_PERSIST_SESSIONS`) narrows it to one daemon when desired.
- When enabled, missing prerequisites are **fatal misconfigurations**, never a quiet skip: `SPOOL` (or `SEC_SESSION_CACHE_FILE`) must be set, and pool signing keys (`SEC_PASSWORD_DIRECTORY`) must be available — they encrypt the database at rest, so there is no plaintext fallback.
- `SEC_SESSION_CACHE_FILE` overrides the default path; `SEC_SESSION_SNAPSHOT_INTERVAL` (seconds) the snapshot cadence; both scope per-subsystem the same way.
- Default filename: `$(SPOOL)/sessions_<subsys>[_<localname>].db` — the common `sessions_` prefix supports a one-glob spool-cleanup exclusion (`VALID_SPOOL_FILES = sessions_*`), while subsystem + `Options.LocalName` keep instances sharing a SPOOL apart.
- A binary that already called `EnableSessionPersistence` itself is left alone.

Also switches `sessioncache/sqlite` from `modernc.org/sqlite` to `github.com/glebarez/go-sqlite` (the modernc-derived pure-Go engine the webapi GORM stack already links). Both register the `"sqlite"` `database/sql` driver, so a binary linking both panics at init (`sql: Register called twice`) — the CI failure in `webapi/cmd/htcondor-api` on the previous revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
