### PR TITLE
sessioncache/sqlite: create the session database 0600, not umask-default

### DIFF
--- a/sessioncache/sqlite/store.go
+++ b/sessioncache/sqlite/store.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"log/slog"
+	"os"
 	"sync"
 	"time"
 
@@ -60,6 +61,15 @@ func Open(path string, keys []SigningKey, log *slog.Logger) (sessioncache.Sessio
 	// deadlock; taking the write lock at BEGIN avoids that. busy_timeout guards
 	// transient locks; WAL + NORMAL trade an fsync per commit for a single fsync
 	// at checkpoint while remaining crash-safe.
+	// The database holds encrypted session records, but its metadata (and its
+	// -wal/-shm sidecars, which SQLite creates with the database file's own
+	// permissions) should not be world-readable. Create the file 0600 up front,
+	// and tighten an existing one that predates this -- SQLite would otherwise
+	// create it honoring the process umask (typically 0644). Best-effort: a chmod
+	// failure is logged, not fatal, so an unusual filesystem does not block startup.
+	if err := ensureFileMode(path, 0o600); err != nil {
+		log.Warn("could not restrict session database permissions", "path", path, "err", err)
+	}
 	dsn := fmt.Sprintf("file:%s?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)", path)
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
@@ -77,6 +87,23 @@ func Open(path string, keys []SigningKey, log *slog.Logger) (sessioncache.Sessio
 		return nil, err
 	}
 	return s, nil
+}
+
+// ensureFileMode makes path exist with exactly mode, creating it if absent and
+// tightening it if it already exists with looser bits. Creating the file here
+// (rather than letting SQLite create it under the umask) means SQLite opens an
+// existing file and propagates its permissions to the -wal/-shm sidecars.
+func ensureFileMode(path string, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_CREATE, mode)
+	if err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	// O_CREATE's mode applies only on creation; chmod covers a pre-existing file
+	// (and corrects for the umask, which masks the create mode too).
+	return os.Chmod(path, mode)
 }
 
 // migrate applies the embedded goose migrations, creating/evolving the schema.

--- a/sessioncache/sqlite/store.go
+++ b/sessioncache/sqlite/store.go
@@ -94,7 +94,9 @@ func Open(path string, keys []SigningKey, log *slog.Logger) (sessioncache.Sessio
 // (rather than letting SQLite create it under the umask) means SQLite opens an
 // existing file and propagates its permissions to the -wal/-shm sidecars.
 func ensureFileMode(path string, mode os.FileMode) error {
-	f, err := os.OpenFile(path, os.O_CREATE, mode)
+	// path is the configured session-database location, not attacker-controlled.
+	f, err := os.OpenFile(path, os.O_CREATE, mode) //nolint:gosec // G304: path is operator-configured
+
 	if err != nil {
 		return err
 	}

--- a/sessioncache/sqlite/store_test.go
+++ b/sessioncache/sqlite/store_test.go
@@ -218,3 +218,55 @@ func TestSessionStoreDeltaWrites(t *testing.T) {
 		t.Errorf("after delta, expected only sess-1, got %+v", got)
 	}
 }
+
+// TestOpenRestrictsFileMode verifies the session database and its WAL/shared
+// sidecars are created 0600 (not world/group readable), and that an existing
+// looser file is tightened on reopen. Contents are encrypted, but the metadata
+// should not be readable either.
+func TestOpenRestrictsFileMode(t *testing.T) {
+	// A permissive umask so the mode we assert is the store's doing, not the
+	// environment's -- without the fix SQLite would create the file 0666&~umask.
+	old := syscallUmask(0)
+	defer syscallUmask(old)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sessions_test.db")
+
+	st := openStore(t, path, []SigningKey{sk("POOL", 1)})
+	// A write plus a checkpoint materializes the -wal and -shm sidecars.
+	if err := st.Save(context.Background(), sampleRecords()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.db.ExecContext(context.Background(), `PRAGMA wal_checkpoint(PASSIVE)`); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		p := path + suffix
+		info, err := os.Stat(p)
+		if err != nil {
+			if suffix != "" {
+				continue // sidecar may not exist on every platform/config
+			}
+			t.Fatalf("stat %s: %v", p, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("%s mode = %o, want 600", p, perm)
+		}
+	}
+	_ = st.Close()
+
+	// A pre-existing looser file must be tightened on reopen.
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	st2 := openStore(t, path, []SigningKey{sk("POOL", 1)})
+	defer st2.Close()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("reopen did not tighten mode: %o, want 600", perm)
+	}
+}

--- a/sessioncache/sqlite/store_test.go
+++ b/sessioncache/sqlite/store_test.go
@@ -257,11 +257,11 @@ func TestOpenRestrictsFileMode(t *testing.T) {
 	_ = st.Close()
 
 	// A pre-existing looser file must be tightened on reopen.
-	if err := os.Chmod(path, 0o644); err != nil {
+	if err := os.Chmod(path, 0o644); err != nil { //nolint:gosec // G302: deliberately loosening to test tightening
 		t.Fatal(err)
 	}
 	st2 := openStore(t, path, []SigningKey{sk("POOL", 1)})
-	defer st2.Close()
+	defer func() { _ = st2.Close() }()
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatal(err)

--- a/sessioncache/sqlite/umask_unix_test.go
+++ b/sessioncache/sqlite/umask_unix_test.go
@@ -1,0 +1,7 @@
+//go:build unix
+
+package sqlite
+
+import "golang.org/x/sys/unix"
+
+func syscallUmask(mask int) int { return unix.Umask(mask) }


### PR DESCRIPTION
The session records are encrypted at rest, but the database file and its `-wal`/`-shm` sidecars were created honoring the process umask (typically `0644`), leaving the file **metadata** group/world-readable:

```
-rw-r--r-- condor condor sessions_collector_htcview.db
-rw-r--r-- condor condor sessions_collector_htcview.db-shm
-rw-r--r-- condor condor sessions_collector_htcview.db-wal
```

SQLite creates the WAL and shared-memory files with the **database file's own** permissions, so creating the main file `0600` before opening (and tightening a pre-existing looser file on reopen) makes all three `0600`. A chmod failure is logged, not fatal, so an unusual filesystem doesn't block daemon startup.

Test asserts all three files land at `0600` under a permissive umask, and that a reopened `0644` file is tightened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
