### PR TITLE
config: accept unquoted include paths and commands

### DIFF
--- a/config/integration_test.go
+++ b/config/integration_test.go
@@ -436,6 +436,48 @@ func TestIncludeCommand(t *testing.T) {
 			t.Errorf("CMD_VAR: got %q, want %q", val, "from_command")
 		}
 	})
+
+	// Unquoted command with arguments — the HTCondor-native form
+	// (`include command : /usr/bin/foo -a -b`), which motivated the fix.
+	t.Run("UnquotedCommandWithArgs", func(t *testing.T) {
+		rootConfig := filepath.Join(tmpDir, "root_unquoted_cmd.config")
+		content := "include command : /bin/echo UNQUOTED_VAR = from_unquoted\n"
+		if err := os.WriteFile(rootConfig, []byte(content), 0600); err != nil {
+			t.Fatalf("Failed to create root config: %v", err)
+		}
+
+		cfg, err := NewFromReaderWithOptions(mustOpen(t, rootConfig), ConfigOptions{})
+		if err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		if val, ok := cfg.Get("UNQUOTED_VAR"); !ok || val != "from_unquoted" {
+			t.Errorf("UNQUOTED_VAR: got %q, want %q", val, "from_unquoted")
+		}
+	})
+}
+
+// TestIncludeUnquotedFile checks an unquoted `include : <path>` (HTCondor's
+// native form — no quotes, path runs to end of line).
+func TestIncludeUnquotedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	includedFile := filepath.Join(tmpDir, "included.config")
+	if err := os.WriteFile(includedFile, []byte("FROM_UNQUOTED_INCLUDE = yes\n"), 0600); err != nil {
+		t.Fatalf("Failed to create included file: %v", err)
+	}
+	rootConfig := filepath.Join(tmpDir, "root_unquoted.config")
+	content := fmt.Sprintf("ROOT_VAR = from_root\ninclude : %s\n", includedFile)
+	if err := os.WriteFile(rootConfig, []byte(content), 0600); err != nil {
+		t.Fatalf("Failed to create root config: %v", err)
+	}
+
+	cfg, err := NewFromReaderWithOptions(mustOpen(t, rootConfig), ConfigOptions{})
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+	if val, ok := cfg.Get("FROM_UNQUOTED_INCLUDE"); !ok || val != "yes" {
+		t.Errorf("FROM_UNQUOTED_INCLUDE: got %q, want %q", val, "yes")
+	}
 }
 
 // TestIncludeCommandWithCache tests "include command into <cache> : <cmdline>"

--- a/config/lexer.go
+++ b/config/lexer.go
@@ -53,6 +53,15 @@ type Lexer struct {
 	afterIfOrElif       bool // True if the previous token was IF or ELIF
 	afterErrorOrWarning bool // True if the previous token was ERROR or WARNING
 
+	// inInclude is true while lexing an include directive's type keywords
+	// (INCLUDE, and any continuation COMMAND/IFEXIST) up to its ':'. It lets the
+	// ':' know it terminates an include type, so the path/command that follows is
+	// read as the rest of the line. afterIncludeColon carries that across to the
+	// next token: an include path or command is unquoted in HTCondor
+	// (`include command : /usr/bin/foo -a -b`), not an IDENT/STRING.
+	inInclude         bool
+	afterIncludeColon bool
+
 	// stmtStart is true when the next token begins a new statement (line).
 	// prevIdentAssignable is true when the immediately preceding token was a
 	// statement-start plain identifier — i.e. an assignment target — so a
@@ -472,6 +481,25 @@ func (l *Lexer) NextToken() *TokenInfo {
 		return tok
 	}
 
+	// Special handling after an include directive's ':' — the file path or
+	// command is unquoted and runs to end of line in HTCondor
+	// (`include : /etc/condor/foo`, `include command : /usr/bin/sudo ...`), so
+	// read it whole as a STRING. A quoted argument (`include : "..."`) falls
+	// through to normal string lexing, preserving quote stripping.
+	if l.afterIncludeColon {
+		l.afterIncludeColon = false
+		l.skipWhitespace()
+		if l.ch != '"' && l.ch != '\'' {
+			tok := &TokenInfo{
+				Line: l.line,
+				Col:  l.col,
+			}
+			tok.Token = STRING
+			tok.Lit = l.readUntilNewline()
+			return tok
+		}
+	}
+
 	l.skipWhitespace()
 
 	tok := &TokenInfo{
@@ -484,8 +512,10 @@ func (l *Lexer) NextToken() *TokenInfo {
 	// previous token a statement-start plain identifier (so ':' means assign)?
 	atStmtStart := l.stmtStart
 	colonAssignable := l.prevIdentAssignable
+	wasInInclude := l.inInclude
 	l.stmtStart = false
 	l.prevIdentAssignable = false
+	l.inInclude = false
 
 	switch l.ch {
 	case 0:
@@ -531,6 +561,10 @@ func (l *Lexer) NextToken() *TokenInfo {
 			tok.Token = COLON
 			tok.Lit = ":"
 			l.readChar()
+			// A ':' ending an include type introduces the (unquoted) path/command.
+			if wasInInclude {
+				l.afterIncludeColon = true
+			}
 		}
 
 	case '(':
@@ -596,6 +630,14 @@ func (l *Lexer) NextToken() *TokenInfo {
 				switch kw {
 				case USE:
 					l.afterUse = true
+				case INCLUDE:
+					l.inInclude = true
+				case COMMAND, IFEXIST:
+					// Continuation keywords of an include type: keep the flag alive
+					// so the terminating ':' still introduces the path/command.
+					if wasInInclude {
+						l.inInclude = true
+					}
 				case IF, ELIF:
 					l.afterIfOrElif = true
 				case ERROR, WARNING:

--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -175,6 +175,33 @@ func TestParseIncludeDirectiveWithColon(t *testing.T) {
 			expectedType: "include_command",
 			expectedPath: "echo 'VAR = value'",
 		},
+		{
+			// HTCondor include paths are unquoted and run to end of line.
+			name:         "include unquoted path",
+			input:        `include : /etc/condor/config.d/00-common`,
+			expectedType: "include",
+			expectedPath: "/etc/condor/config.d/00-common",
+		},
+		{
+			// The real-world config that motivated this: an unquoted command
+			// with an absolute path, flags, and arguments.
+			name:         "include command unquoted with args",
+			input:        `include command : /usr/bin/sudo /usr/local/sbin/htcondor/config_sync.sh -d /usr/local/etc/condor -r origin -b master`,
+			expectedType: "include_command",
+			expectedPath: "/usr/bin/sudo /usr/local/sbin/htcondor/config_sync.sh -d /usr/local/etc/condor -r origin -b master",
+		},
+		{
+			name:         "include ifexist unquoted path",
+			input:        `include ifexist : /opt/condor/local.config`,
+			expectedType: "include_ifexist",
+			expectedPath: "/opt/condor/local.config",
+		},
+		{
+			name:         "include unquoted pipe command",
+			input:        `include : /usr/bin/generate-config |`,
+			expectedType: "include_command",
+			expectedPath: "/usr/bin/generate-config",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### The bug

htcondordb (and any golang-htcondor daemon) failed to start against a stock HTCondor config:

```
htcondordb: loading config: error parsing /etc/condor/condor_config.local:
parse error at line 16, col 21 (near "/"): syntax error: unexpected ILLEGAL, expecting IDENT or STRING
```

from an ordinary directive:

```conf
include command : /usr/bin/sudo /usr/local/sbin/htcondor/config_sync.sh -d /usr/local/etc/condor -r origin -b master
```

### Cause

HTCondor `include` directives take an **unquoted** argument that runs to end of line — both `include : /etc/condor/foo` and `include command : /usr/bin/... -a -b`. The lexer only produced a usable token after the `:` when the argument was a quoted `STRING` or a bare `IDENT`, so an absolute path (leading `/`) — or any command with slashes, flags, or spaces — lexed the `/` as `ILLEGAL`. Every existing test quoted the argument, hiding it.

### Fix

Track being inside an include type (`INCLUDE` plus any continuation `COMMAND`/`IFEXIST`) up to its `:`; that `:` then reads the rest of the line as the path/command — the same mechanism already used after `USE`, `IF`/`ELIF`, and `ERROR`/`WARNING`. A **quoted** argument still falls through to normal string lexing, so quote stripping and all existing include tests are unchanged.

Tests: unquoted path, unquoted `include command` with an absolute path + flags + args (the exact failing line), unquoted `ifexist`, unquoted pipe form, and an end-to-end `include command : /bin/echo ...` execution. Full `config` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
