### PR TITLE
config: apply subsystem scoping during macro expansion

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -863,9 +863,12 @@ func (c *Config) expandMacros(value string) (string, error) {
 
 		c.evaluating[varName] = true
 
-		// Get value
+		// Get value. Resolve through the subsystem/local-name scoping that Get()
+		// uses, so `$(IsMaster)` under SUBSYSTEM=MASTER expands via MASTER.IsMaster,
+		// and any `$(KNOB)` picks up a `SUBSYS.KNOB` override -- matching HTCondor,
+		// where macro expansion is subsystem-scoped.
 		replacement := defaultVal
-		if val, ok := c.values[varName]; ok {
+		if val, ok := c.values[c.scopedLookupKey(varName)]; ok {
 			replacement = val
 		}
 

--- a/config/functions.go
+++ b/config/functions.go
@@ -304,7 +304,11 @@ func (c *Config) expandMacrosWithFunctions(value string) (string, error) {
 					}
 
 					c.evaluating[varName] = true
-					replacement, ok := c.values[varName]
+					// Resolve through subsystem/local-name scoping (as Get does), so
+					// `$(IsMaster)` under SUBSYSTEM=MASTER expands via MASTER.IsMaster
+					// and any `$(KNOB)` honors a `SUBSYS.KNOB` override, matching
+					// HTCondor's subsystem-scoped macro expansion.
+					replacement, ok := c.values[c.scopedLookupKey(varName)]
 					if !ok {
 						replacement = defaultVal
 					}

--- a/config/subsystem_scope_test.go
+++ b/config/subsystem_scope_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMacroExpansionSubsystemScoping verifies macro expansion honors the same
+// subsystem/local-name scoping that Get() does, matching HTCondor. The
+// motivating case is the predefined Is<Subsystem> family (param_defaults:
+// IsMaster=false, MASTER.IsMaster=true, ...): `if $(IsMaster)` must be true
+// only under SUBSYSTEM=MASTER, and a `SUBSYS.KNOB` override must reach `$(KNOB)`.
+func TestMacroExpansionSubsystemScoping(t *testing.T) {
+	// The Is<Subsystem> booleans: true only for the matching subsystem.
+	isCases := []struct {
+		subsys string
+		macro  string
+		want   string
+	}{
+		{"MASTER", "IsMaster", "true"},
+		{"COLLECTOR", "IsCollector", "true"},
+		{"SCHEDD", "IsSchedd", "true"},
+		{"STARTD", "IsStartd", "true"},
+		{"NEGOTIATOR", "IsNegotiator", "true"},
+		// A non-daemon subsystem sees them all false -- the htcondordb case, where
+		// `if $(IsMaster)` correctly skips a master-only block.
+		{"HTCONDORDB", "IsMaster", "false"},
+		{"HTCONDORDB", "IsCollector", "false"},
+		{"COLLECTOR", "IsMaster", "false"},
+	}
+	for _, tc := range isCases {
+		cfg, err := NewFromReaderWithOptions(strings.NewReader(""), ConfigOptions{Subsystem: tc.subsys})
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, _ := cfg.expandMacrosWithFunctions("$(" + tc.macro + ")")
+		if got != tc.want {
+			t.Errorf("subsys=%s: $(%s) expanded to %q, want %q", tc.subsys, tc.macro, got, tc.want)
+		}
+		// Expansion must agree with Get(), which already scopes.
+		if viaGet, _ := cfg.Get(tc.macro); viaGet != tc.want {
+			t.Errorf("subsys=%s: Get(%s)=%q, want %q", tc.subsys, tc.macro, viaGet, tc.want)
+		}
+	}
+
+	// A user-defined SUBSYS.KNOB override must reach $(KNOB) during expansion.
+	cfg, err := NewFromReaderWithOptions(strings.NewReader(
+		"FOO = base\nMASTER.FOO = master-only\n"), ConfigOptions{Subsystem: "MASTER"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := cfg.expandMacrosWithFunctions("$(FOO)"); got != "master-only" {
+		t.Errorf("$(FOO) under MASTER expanded to %q, want %q (scoped override missed)", got, "master-only")
+	}
+	// A different subsystem falls back to the unscoped value.
+	cfg2, err := NewFromReaderWithOptions(strings.NewReader(
+		"FOO = base\nMASTER.FOO = master-only\n"), ConfigOptions{Subsystem: "SCHEDD"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := cfg2.expandMacrosWithFunctions("$(FOO)"); got != "base" {
+		t.Errorf("$(FOO) under SCHEDD expanded to %q, want %q (should not see MASTER scope)", got, "base")
+	}
+}
+
+// TestIfIsMasterConditional exercises the end-to-end conditional: a master-only
+// block guarded by `if $(IsMaster)` runs under MASTER and is skipped otherwise.
+func TestIfIsMasterConditional(t *testing.T) {
+	const cfgText = `if $(IsMaster)
+  MASTER_ONLY = yes
+endif
+`
+	for _, tc := range []struct {
+		subsys  string
+		wantSet bool
+	}{
+		{"MASTER", true},
+		{"HTCONDORDB", false},
+		{"SCHEDD", false},
+	} {
+		cfg, err := NewFromReaderWithOptions(strings.NewReader(cfgText), ConfigOptions{Subsystem: tc.subsys})
+		if err != nil {
+			t.Fatalf("subsys=%s: %v", tc.subsys, err)
+		}
+		_, ok := cfg.Get("MASTER_ONLY")
+		if ok != tc.wantSet {
+			t.Errorf("subsys=%s: MASTER_ONLY set=%v, want %v", tc.subsys, ok, tc.wantSet)
+		}
+	}
+}


### PR DESCRIPTION
### The bug (found while reviewing `if $(IsMaster)` in a real config)

The `Is<Subsystem>` macros are predefined in `param_defaults.go` using HTCondor's scoped-key trick — `IsMaster=false` with `MASTER.IsMaster=true`, and one pair per daemon. `Get("IsMaster")` resolves these correctly via `scopedLookupKey`, but **macro expansion did a raw `c.values[name]` lookup with no scoping**. So expansion and `Get()` disagreed:

| subsystem | `$(IsMaster/IsX)` expansion (before) | `Get()` |
|---|---|---|
| MASTER | `false` ❌ | `true` |
| COLLECTOR `$(IsCollector)` | `false` ❌ | `true` |
| SCHEDD `$(IsSchedd)` | `false` ❌ | `true` |
| HTCONDORDB `$(IsMaster)` | `false` ✓ | `false` |

Consequences: `if $(IsMaster)` never fired under the master; `if $(IsCollector)` never fired for the collector — a Go daemon would **skip a block HTCondor runs**. More generally, any `$(KNOB)` relying on a `SUBSYS.KNOB` override expanded unscoped.

(htcondordb was unaffected in practice: it isn't the master, so the always-`false` answer happened to be correct.)

### Fix

Resolve through `scopedLookupKey` in both `expandMacros` and `expandMacrosWithFunctions`, so expansion is subsystem-scoped like HTCondor and consistent with `Get()`. htcondordb behavior is unchanged.

Tests: the full `Is<Subsystem>` matrix (true only for the matching subsystem; all false for a non-daemon subsystem), a user `SUBSYS.KNOB` override reaching `$(KNOB)` (and not leaking to other subsystems), and the end-to-end `if $(IsMaster)` block running under MASTER / skipped under HTCONDORDB and SCHEDD. Full config suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
