### PR TITLE
daemon: PublishAd -- generic self-advertisement base ad (DaemonCore::publish analogue)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -80,6 +80,11 @@ type Daemon struct {
 	adoptedInherited bool   // Listener returned an inherited socket (shared-port or #119), not the fallback
 	stopAlive        func()
 	onReconfig       []func(*config.Config)
+
+	// startTime is the daemon's construction time (DaemonStartTime); lastReconfig is the last
+	// SIGHUP reconfigure (DaemonLastReconfigTime), 0 until the first. Both feed PublishAd.
+	startTime    time.Time
+	lastReconfig atomic.Int64
 }
 
 // New constructs a Daemon: it loads configuration and logging, and — when
@@ -135,6 +140,7 @@ func New(opts Options) (*Daemon, error) {
 		log:        logger,
 		grace:      grace,
 		shutdownCh: make(chan struct{}),
+		startTime:  time.Now(),
 	}
 	d.cfg.Store(cfg)
 
@@ -444,6 +450,7 @@ func (d *Daemon) reconfigure() {
 		return
 	}
 	d.cfg.Store(cfg)
+	d.lastReconfig.Store(time.Now().Unix())
 	// Re-apply per-destination log levels from the reloaded config, so condor_reconfig
 	// changes log verbosity on the running daemon (the levels are held in a live atomic
 	// snapshot the installed handlers read).

--- a/daemon/publish_ad.go
+++ b/daemon/publish_ad.go
@@ -1,0 +1,153 @@
+package daemon
+
+import (
+	"math"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/PelicanPlatform/classad/classad"
+
+	"github.com/bbockelm/golang-htcondor/config"
+	"github.com/bbockelm/golang-htcondor/version"
+)
+
+// PublishAd fills ad with the common daemon attributes every collector advertisement carries --
+// the Go analogue of C++ DaemonCore::publish() + config_fill_ad(). A daemon seeds a base ad with
+// this, then adds its own subsystem attributes (and sets MyType) before sending it to a
+// collector. PublishAd does NOT set MyType, which is subsystem-specific.
+//
+// It publishes identity (Name, Machine FQDN, MyAddress), CondorVersion/CondorPlatform,
+// MyCurrentTime, DaemonStartTime/DaemonLastReconfigTime, PrivateNetworkName, a subset of the
+// self-monitoring MonitorSelf* stats, and any admin-configured <SUBSYS>_ATTRS attributes (so an
+// operator can augment every advertisement via configuration, exactly as with a C++ daemon).
+func (d *Daemon) PublishAd(ad *classad.ClassAd) {
+	cfg := d.cfg.Load()
+	now := time.Now()
+
+	ad.InsertAttr("MyCurrentTime", now.Unix())
+	ad.InsertAttrString("CondorVersion", CondorVersion())
+	ad.InsertAttrString("CondorPlatform", CondorPlatform())
+	ad.InsertAttr("DaemonStartTime", d.startTime.Unix())
+	if r := d.lastReconfig.Load(); r > 0 {
+		ad.InsertAttr("DaemonLastReconfigTime", r)
+	}
+	if m := configGet(cfg, "FULL_HOSTNAME"); m != "" {
+		ad.InsertAttrString("Machine", m)
+	}
+	if addr, ok := d.AdvertisedSinful(); ok && addr != "" {
+		ad.InsertAttrString("MyAddress", ensureAngle(addr))
+	}
+	if pnn := configGet(cfg, "PRIVATE_NETWORK_NAME"); pnn != "" {
+		ad.InsertAttrString("PrivateNetworkName", pnn)
+	}
+	ad.InsertAttrString("Name", d.adName(cfg))
+
+	d.publishMonitorSelf(ad, now)
+	d.fillConfigAttrs(ad, cfg)
+}
+
+// CondorVersion / CondorPlatform format the library's version/platform in the HTCondor
+// "$CondorVersion: ... $" / "$CondorPlatform: ... $" shapes (BuildID marks golang-htcondor), the
+// values a C++ daemon publishes via CondorVersion()/CondorPlatform().
+func CondorVersion() string {
+	return "$CondorVersion: " + version.Version + " BuildID: golang-htcondor-" + version.Commit + " $"
+}
+
+// CondorPlatform returns the "$CondorPlatform: <arch>_<os> $" string a C++ daemon publishes.
+func CondorPlatform() string {
+	return "$CondorPlatform: " + runtime.GOARCH + "_" + runtime.GOOS + " $"
+}
+
+// adName returns the daemon's advertised Name: <SUBSYS>_NAME if configured, else
+// <subsys>@<full-hostname>.
+func (d *Daemon) adName(cfg *config.Config) string {
+	if n := configGet(cfg, d.subsys+"_NAME"); n != "" {
+		return n
+	}
+	host := configGet(cfg, "FULL_HOSTNAME")
+	if host == "" {
+		host, _ = os.Hostname()
+	}
+	return strings.ToLower(d.subsys) + "@" + host
+}
+
+// publishMonitorSelf adds the self-monitoring gauges a Prometheus exporter (or condor_status)
+// reads. Age comes from the daemon's start time; the memory figures are the Go runtime's view
+// (Sys ~ address space obtained from the OS, HeapAlloc ~ live heap) rather than the OS process
+// RSS, and are reported in KiB to match the HTCondor MonitorSelf* convention.
+func (d *Daemon) publishMonitorSelf(ad *classad.ClassAd, now time.Time) {
+	ad.InsertAttr("MonitorSelfTime", now.Unix())
+	ad.InsertAttr("MonitorSelfAge", int64(now.Sub(d.startTime).Seconds()))
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	ad.InsertAttr("MonitorSelfImageSize", kib(ms.Sys))
+	ad.InsertAttr("MonitorSelfResidentSetSize", kib(ms.HeapAlloc))
+}
+
+// kib converts a byte count to a KiB int64, saturating rather than overflowing (a process
+// never approaches the bound, but the explicit clamp keeps the uint64->int64 conversion safe).
+func kib(bytes uint64) int64 {
+	kb := bytes / 1024
+	if kb > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(kb)
+}
+
+// fillConfigAttrs mirrors config_fill_ad: it publishes each attribute named in <SUBSYS>_ATTRS
+// (and <SUBSYS>_EXPRS, SYSTEM_<SUBSYS>_ATTRS, and the local-name-prefixed forms) by inserting
+// that attribute's configured value -- parsed as a ClassAd expression, falling back to a string.
+func (d *Daemon) fillConfigAttrs(ad *classad.ClassAd, cfg *config.Config) {
+	subsys := d.subsys
+	local := cfg.Options().LocalName
+
+	var names []string
+	seen := map[string]bool{}
+	addList := func(key string) {
+		for _, a := range splitConfigList(configGet(cfg, key)) {
+			if !seen[a] {
+				seen[a] = true
+				names = append(names, a)
+			}
+		}
+	}
+	addList(subsys + "_ATTRS")
+	addList(subsys + "_EXPRS")
+	addList("SYSTEM_" + subsys + "_ATTRS")
+	if local != "" {
+		addList(local + "_" + subsys + "_ATTRS")
+		addList(local + "_" + subsys + "_EXPRS")
+	}
+
+	for _, name := range names {
+		val := configGet(cfg, name)
+		if val == "" {
+			continue
+		}
+		if expr, err := classad.ParseExpr(val); err == nil {
+			ad.InsertExpr(name, expr)
+		} else {
+			ad.InsertAttrString(name, val)
+		}
+	}
+}
+
+func configGet(cfg *config.Config, key string) string {
+	v, _ := cfg.Get(key)
+	return strings.TrimSpace(v)
+}
+
+func splitConfigList(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	})
+}
+
+func ensureAngle(addr string) string {
+	if strings.HasPrefix(addr, "<") {
+		return addr
+	}
+	return "<" + addr + ">"
+}

--- a/daemon/publish_ad_test.go
+++ b/daemon/publish_ad_test.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/classad"
+
+	"github.com/bbockelm/golang-htcondor/config"
+)
+
+func TestPublishAd(t *testing.T) {
+	cfg := config.NewEmpty()
+	cfg.Set("FULL_HOSTNAME", "ap40.chtc.wisc.edu")
+	cfg.Set("PRIVATE_NETWORK_NAME", "chtc")
+	// Admin-published attributes, the config_fill_ad mechanism.
+	cfg.Set("HTCONDORDB_ATTRS", "PoolName, MaxJobs")
+	cfg.Set("PoolName", `"CHTC"`)
+	cfg.Set("MaxJobs", "100000")
+
+	d := &Daemon{subsys: "HTCONDORDB", startTime: time.Now().Add(-90 * time.Second)}
+	d.cfg.Store(cfg)
+
+	ad := classad.New()
+	d.PublishAd(ad)
+
+	str := func(k string) string { v, _ := ad.EvaluateAttrString(k); return v }
+	i := func(k string) int64 { v, _ := ad.EvaluateAttrInt(k); return v }
+
+	if str("Machine") != "ap40.chtc.wisc.edu" {
+		t.Errorf("Machine = %q", str("Machine"))
+	}
+	if str("Name") != "htcondordb@ap40.chtc.wisc.edu" {
+		t.Errorf("Name = %q, want htcondordb@ap40.chtc.wisc.edu", str("Name"))
+	}
+	if str("PrivateNetworkName") != "chtc" {
+		t.Errorf("PrivateNetworkName = %q", str("PrivateNetworkName"))
+	}
+	if v := str("CondorVersion"); !strings.HasPrefix(v, "$CondorVersion:") || !strings.Contains(v, "golang-htcondor") {
+		t.Errorf("CondorVersion = %q", v)
+	}
+	if v := str("CondorPlatform"); !strings.HasPrefix(v, "$CondorPlatform:") {
+		t.Errorf("CondorPlatform = %q", v)
+	}
+	if i("DaemonStartTime") <= 0 || i("MyCurrentTime") <= 0 {
+		t.Errorf("timing attrs missing")
+	}
+	if age := i("MonitorSelfAge"); age < 80 || age > 3600 {
+		t.Errorf("MonitorSelfAge = %d, want ~90", age)
+	}
+	if i("MonitorSelfImageSize") <= 0 {
+		t.Errorf("MonitorSelfImageSize should be > 0")
+	}
+
+	// config_fill_ad: the two admin-published attributes appear with their configured values.
+	if str("PoolName") != "CHTC" {
+		t.Errorf("PoolName = %q, want CHTC (from HTCONDORDB_ATTRS)", str("PoolName"))
+	}
+	if i("MaxJobs") != 100000 {
+		t.Errorf("MaxJobs = %d, want 100000 (from HTCONDORDB_ATTRS)", i("MaxJobs"))
+	}
+}
+
+// TestPublishAdNameOverride: <SUBSYS>_NAME overrides the default subsys@host name.
+func TestPublishAdNameOverride(t *testing.T) {
+	cfg := config.NewEmpty()
+	cfg.Set("FULL_HOSTNAME", "h1")
+	cfg.Set("HTCONDORDB_NAME", "primary-db")
+	d := &Daemon{subsys: "HTCONDORDB", startTime: time.Now()}
+	d.cfg.Store(cfg)
+	ad := classad.New()
+	d.PublishAd(ad)
+	if v, _ := ad.EvaluateAttrString("Name"); v != "primary-db" {
+		t.Errorf("Name = %q, want primary-db", v)
+	}
+}


### PR DESCRIPTION
Advertising to the collector is a generic **DaemonCore** capability in C++: `DaemonCore::publish()` + `config_fill_ad()` fill a base ad with the common attributes every daemon shares, and each daemon *augments* that with its subsystem attributes before `sendUpdates()`. The Go `daemon` package had no equivalent — only `AdvertisedSinful()` — so every would-be advertiser had to hand-roll identity.

`daemon.PublishAd(ad)` closes that gap. A daemon seeds a base ad with it, then adds its own attributes (and `MyType`) before sending. It publishes:

- **Identity/version**: `Name` (`<SUBSYS>_NAME` or `<subsys>@<full-hostname>`), `Machine` (FQDN), `MyAddress`, `CondorVersion`, `CondorPlatform`, `MyCurrentTime`.
- **Lifecycle**: `DaemonStartTime`, `DaemonLastReconfigTime` (the daemon now tracks both — start in `New`, reconfig in `reconfigure()`).
- **Self-monitoring**: a subset of the C++ `MonitorSelf*` gauges (`Age`, `Time`, `ImageSize`, `ResidentSetSize`), for `condor_status`/Prometheus.
- **`config_fill_ad`**: any admin-configured `<SUBSYS>_ATTRS` (plus `<SUBSYS>_EXPRS`, `SYSTEM_<SUBSYS>_ATTRS`, local-name-prefixed forms), each attribute's configured value parsed as a ClassAd expression — so an operator can add arbitrary attributes to every advertisement via config, exactly as with a C++ daemon.

`CondorVersion()`/`CondorPlatform()` are exported too, for callers needing the strings directly.

Every Go daemon (collector, negotiator, ep, ap, htcondordb) can now self-advertise on top of this instead of reinventing it — the first consumer is htcondordb's `HTCondorDB` monitoring/discovery ad.

### Tests
`PublishAd` fills identity/version/timing/`MonitorSelf*`, resolves `<SUBSYS>_ATTRS` (`HTCONDORDB_ATTRS = PoolName, MaxJobs` → those attrs in the ad), and honors `<SUBSYS>_NAME` override. Full daemon suite green.

### Follow-ups
`AddressV1` (serialized Sinful) and true OS RSS/CPU; a daemon-owned advertise loop mirroring `sendUpdates` (collector list, per-collector sequence numbers, `DAEMON_SHUTDOWN` eval, admin-session capability).
