### PR TITLE
daemon: report the subsystem as DC_SET_READY DaemonName

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -144,6 +144,14 @@ func New(opts Options) (*Daemon, error) {
 		if err != nil {
 			logger.Warn(logging.DestinationGeneral, "running under condor_master but master env unusable; readiness/keepalive disabled", "error", err)
 		} else {
+			// The master learns the daemon's name from the DC_SET_READY ad's
+			// DaemonName. HTCondor does not export _CONDOR_DAEMON_NAME, so without
+			// this the master logs an empty name ("Setting ready state 'Ready' for
+			// "). Fall back to the subsystem, matching how C++ daemons name
+			// themselves (e.g. the startd sends DaemonName = "STARTD").
+			if master.DaemonName() == "" {
+				master.SetDaemonName(opts.Subsys)
+			}
 			d.master = master
 			logger.Info(logging.DestinationGeneral, "detected condor_master parent",
 				"parent_pid", master.ParentPID(), "master_addr", master.Address())

--- a/daemon/readyname_test.go
+++ b/daemon/readyname_test.go
@@ -1,0 +1,46 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/bbockelm/golang-htcondor/config"
+)
+
+// TestReadyNameFallsBackToSubsystem verifies that when running under
+// condor_master without _CONDOR_DAEMON_NAME (HTCondor does not export it), the
+// daemon reports its subsystem as the DC_SET_READY DaemonName, so the master
+// does not log an empty "Setting ready state 'Ready' for ".
+func TestReadyNameFallsBackToSubsystem(t *testing.T) {
+	t.Setenv("CONDOR_CONFIG", "/dev/null")
+	// Under condor_master: CONDOR_INHERIT = "<parentPID> <master-sinful>".
+	t.Setenv("CONDOR_INHERIT", "1234 <127.0.0.1:9618>")
+	t.Setenv("_CONDOR_DAEMON_NAME", "") // explicitly unset, as in a real master
+
+	d, err := New(Options{Subsys: "HTCONDORDB", Config: config.NewEmpty()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := d.Master()
+	if m == nil {
+		t.Fatal("expected a master (running under condor_master), got nil")
+	}
+	if got := m.DaemonName(); got != "HTCONDORDB" {
+		t.Errorf("ready DaemonName = %q, want %q (subsystem fallback)", got, "HTCONDORDB")
+	}
+}
+
+// TestReadyNamePrefersEnv verifies an explicit _CONDOR_DAEMON_NAME (if a future
+// master ever exports it) is not overwritten by the subsystem fallback.
+func TestReadyNamePrefersEnv(t *testing.T) {
+	t.Setenv("CONDOR_CONFIG", "/dev/null")
+	t.Setenv("CONDOR_INHERIT", "1234 <127.0.0.1:9618>")
+	t.Setenv("_CONDOR_DAEMON_NAME", "HTCONDORDB_VIEW")
+
+	d, err := New(Options{Subsys: "HTCONDORDB", Config: config.NewEmpty()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := d.Master().DaemonName(); got != "HTCONDORDB_VIEW" {
+		t.Errorf("ready DaemonName = %q, want %q (env should win)", got, "HTCONDORDB_VIEW")
+	}
+}

--- a/master.go
+++ b/master.go
@@ -135,6 +135,14 @@ func (m *Master) DaemonName() string {
 	return m.daemonName
 }
 
+// SetDaemonName sets the name reported to the master in DC_SET_READY (the
+// "DaemonName" attribute the master logs as "Setting ready state ... for <name>").
+// The master identifies the daemon by PID, so this is for its logging/bookkeeping;
+// callers use it to supply the subsystem name when _CONDOR_DAEMON_NAME is unset.
+func (m *Master) SetDaemonName(name string) {
+	m.daemonName = name
+}
+
 // SendKeepAlive transmits a DC_CHILDALIVE heartbeat to condor_master.
 func (m *Master) SendKeepAlive(ctx context.Context, opts *KeepAliveOptions) error {
 	if m.sender == nil {

--- a/master_test.go
+++ b/master_test.go
@@ -69,6 +69,23 @@ func TestSendReadyDefaults(t *testing.T) {
 	assert.Equal(t, os.Getpid(), call.PID)
 }
 
+// TestSetDaemonName verifies SendReady reports a name set via SetDaemonName
+// (used to supply the subsystem when _CONDOR_DAEMON_NAME is unset, so the
+// master does not log an empty "Setting ready state ... for ").
+func TestSetDaemonName(t *testing.T) {
+	sender := &fakeMasterSender{}
+	master := &Master{address: "<127.0.0.1:9618>", sender: sender}
+	require.Empty(t, master.DaemonName())
+
+	master.SetDaemonName("HTCONDORDB")
+	assert.Equal(t, "HTCONDORDB", master.DaemonName())
+
+	require.NoError(t, master.SendReady(context.Background(), nil))
+	calls := sender.readyCallsSnapshot()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "HTCONDORDB", calls[0].Name)
+}
+
 type fakeMasterSender struct {
 	mu             sync.Mutex
 	keepAliveCalls []keepAliveRequest


### PR DESCRIPTION
### Symptom

The master logs an empty daemon name when htcondordb signals readiness:

```
Started DaemonCore process "/usr/local/sbin/htcondordb", pid and pgroup = 1938025
Setting ready state 'Ready' for
```

### Cause

The master's `DC_SET_READY` handler reads `DaemonName` from the ready ad purely for that log line — it identifies the daemon by **PID** (`FindDaemonByPID`), so readiness itself is registered correctly. The Go daemon populated `DaemonName` only from `_CONDOR_DAEMON_NAME`, but **HTCondor never exports that variable** (confirmed: nothing in the C++ tree sets it), so the attribute was omitted and the master logged an empty name.

### Fix

Fall back to the subsystem name when `_CONDOR_DAEMON_NAME` is unset: add `Master.SetDaemonName`, and `daemon.New` sets it from `Options.Subsys` when building the master. This matches how C++ daemons name themselves — the startd literally sends `readyAd.Assign("DaemonName", "STARTD")`. An explicit `_CONDOR_DAEMON_NAME` still wins.

Purely cosmetic (the PID match was already correct), but the master log now reads `Setting ready state 'Ready' for HTCONDORDB`.

Tests: `SetDaemonName` → `SendReady` carries the name; the daemon under a simulated master falls back to its subsystem; an explicit env value is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
