### PR TITLE
config: $INT()/$REAL() look up a macro name and evaluate ClassAd expressions

### DIFF
--- a/config/functions.go
+++ b/config/functions.go
@@ -76,20 +76,86 @@ func (c *Config) evalENV(args string) (string, error) {
 	return os.Getenv(varName), nil
 }
 
-// evalINT converts a value to an integer
+// evalINT implements HTCondor's $INT(name): the argument is a macro NAME. Look
+// it up, expand any macros in its value, then interpret it as an integer.
 func (c *Config) evalINT(args string) (string, error) {
+	return c.evalNumericMacro(args, true)
+}
+
+// evalNumericMacro implements $INT(name)/$REAL(name). Matching HTCondor's
+// string_is_long_param / string_is_double_param, the argument is treated as a
+// macro name (looked up, falling back to the literal) whose expanded value is
+// first tried as a plain numeric literal and, failing that, evaluated as a
+// ClassAd expression. This is what makes `$INT(HOSTCHECK)` work when HOSTCHECK
+// is a boolean expression like `"$(FULL_HOSTNAME)" == "a" || "..." == "b"`: it
+// yields 1 or 0 rather than erroring out (which silently turned `if $INT(...)`
+// false and skipped the block).
+func (c *Config) evalNumericMacro(args string, wantInt bool) (string, error) {
 	value := strings.TrimSpace(args)
 	if value == "" {
-		return "0", nil
+		if wantInt {
+			return "0", nil
+		}
+		return "0.0", nil
 	}
 
-	// Try to parse as float first (to handle "3.14" -> "3")
-	f, err := strconv.ParseFloat(value, 64)
+	// The argument is a macro name: look it up (scoped, as Get does) and fall
+	// back to the literal when it is not a defined macro.
+	if v, ok := c.values[c.scopedLookupKey(value)]; ok {
+		value = v
+	}
+	// Expand any macros in the resolved value ($(FULL_HOSTNAME), nested $INT, ...).
+	if strings.Contains(value, "$") {
+		expanded, err := c.expandMacrosWithFunctions(value)
+		if err != nil {
+			return "", err
+		}
+		value = expanded
+	}
+	value = strings.TrimSpace(value)
+
+	// Fast path: a plain numeric literal (int or real).
+	if f, err := strconv.ParseFloat(value, 64); err == nil {
+		if wantInt {
+			return strconv.FormatInt(int64(f), 10), nil
+		}
+		return strconv.FormatFloat(f, 'g', -1, 64), nil
+	}
+
+	// Otherwise evaluate it as a ClassAd expression. The value is already fully
+	// macro-expanded to literals, so an empty context suffices (matching
+	// HTCondor's me=NULL). A boolean result coerces to 1/0.
+	name := "INT"
+	if !wantInt {
+		name = "REAL"
+	}
+	expr, err := classad.ParseExpr(value)
 	if err != nil {
-		return "", fmt.Errorf("INT: cannot convert %q to integer", value)
+		return "", fmt.Errorf("%s: %q does not evaluate to a number", name, value)
 	}
-
-	return fmt.Sprintf("%d", int64(f)), nil
+	result := expr.Eval(classad.New())
+	switch {
+	case result.IsBool():
+		b, _ := result.BoolValue()
+		if b {
+			return "1", nil
+		}
+		return "0", nil
+	case result.IsInteger():
+		n, _ := result.IntValue()
+		if wantInt {
+			return strconv.FormatInt(n, 10), nil
+		}
+		return strconv.FormatFloat(float64(n), 'g', -1, 64), nil
+	case result.IsReal():
+		f, _ := result.RealValue()
+		if wantInt {
+			return strconv.FormatInt(int64(f), 10), nil
+		}
+		return strconv.FormatFloat(f, 'g', -1, 64), nil
+	default:
+		return "", fmt.Errorf("%s: %q does not evaluate to a number", name, value)
+	}
 }
 
 // evalSTRING converts a value to a string (essentially a no-op but validates)
@@ -181,18 +247,9 @@ func (c *Config) evalSUBSTR(args string) (string, error) {
 }
 
 // evalREAL converts a value to a real number
+// evalREAL implements HTCondor's $REAL(name): like $INT but yields a real.
 func (c *Config) evalREAL(args string) (string, error) {
-	value := strings.TrimSpace(args)
-	if value == "" {
-		return "0.0", nil
-	}
-
-	f, err := strconv.ParseFloat(value, 64)
-	if err != nil {
-		return "", fmt.Errorf("REAL: cannot convert %q to real number", value)
-	}
-
-	return fmt.Sprintf("%g", f), nil
+	return c.evalNumericMacro(args, false)
 }
 
 // expandMacrosWithFunctions expands both regular and function macros

--- a/config/int_macro_test.go
+++ b/config/int_macro_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestINTMacroEvaluatesExpression covers HTCondor's $INT(name)/$REAL(name)
+// semantics: the argument is a macro name whose expanded value is evaluated as a
+// ClassAd expression. The motivating case is a hostname guard,
+// `HOSTCHECK = "$(FULL_HOSTNAME)" == "a" || "$(FULL_HOSTNAME)" == "b"`, used as
+// `if $INT(HOSTCHECK)`.
+func TestINTMacroEvaluatesExpression(t *testing.T) {
+	newCfg := func(vals map[string]string) *Config {
+		return &Config{values: vals, evaluating: make(map[string]bool)}
+	}
+
+	cases := []struct {
+		name string
+		vals map[string]string
+		expr string
+		want string
+	}{
+		{
+			name: "boolean expression true",
+			vals: map[string]string{
+				"FULL_HOSTNAME": "ap43.uw.osg-htc.org",
+				"HOSTCHECK":     `"$(FULL_HOSTNAME)" == "ap43.uw.osg-htc.org" || "$(FULL_HOSTNAME)" == "ospool-ap4043.chtc.wisc.edu"`,
+			},
+			expr: "$INT(HOSTCHECK)",
+			want: "1",
+		},
+		{
+			name: "boolean expression false",
+			vals: map[string]string{
+				"FULL_HOSTNAME": "other.example.org",
+				"HOSTCHECK":     `"$(FULL_HOSTNAME)" == "ap43.uw.osg-htc.org" || "$(FULL_HOSTNAME)" == "ospool-ap4043.chtc.wisc.edu"`,
+			},
+			expr: "$INT(HOSTCHECK)",
+			want: "0",
+		},
+		{
+			name: "arithmetic expression",
+			vals: map[string]string{"X": "3 + 4"},
+			expr: "$INT(X)",
+			want: "7",
+		},
+		{
+			name: "plain integer literal (fast path)",
+			vals: map[string]string{"N": "42"},
+			expr: "$INT(N)",
+			want: "42",
+		},
+		{
+			name: "real truncates to int",
+			vals: map[string]string{"R": "3.9"},
+			expr: "$INT(R)",
+			want: "3",
+		},
+		{
+			name: "REAL of expression",
+			vals: map[string]string{"R": "1.5 + 2"},
+			expr: "$REAL(R)",
+			want: "3.5",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newCfg(tc.vals)
+			got, err := cfg.expandMacrosWithFunctions(tc.expr)
+			if err != nil {
+				t.Fatalf("%s: %v", tc.expr, err)
+			}
+			if got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.expr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIfINTGuardsKnob is the end-to-end reproduction: `if $INT(HOSTCHECK)`
+// guarding a JOB_QUEUE_LOG assignment. The block must be taken only when the
+// hostname matches -- previously $INT errored, the if silently went false, and
+// the knob was never set.
+func TestIfINTGuardsKnob(t *testing.T) {
+	// Use a knob with no param default so Get() reflects only the conditional
+	// (JOB_QUEUE_LOG has a built-in default that would mask the "unset" case).
+	const tmpl = `FULL_HOSTNAME = %s
+HOSTCHECK = "$(FULL_HOSTNAME)" == "ap43.uw.osg-htc.org" || "$(FULL_HOSTNAME)" == "ospool-ap4043.chtc.wisc.edu"
+if $INT(HOSTCHECK)
+  TEST_GUARDED_KNOB = /var/lib/condor/job_queue/job_queue.log
+endif
+`
+	t.Run("hostname matches -> knob set", func(t *testing.T) {
+		cfg, err := NewFromReader(strings.NewReader(fmt.Sprintf(tmpl, "ap43.uw.osg-htc.org")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, ok := cfg.Get("TEST_GUARDED_KNOB")
+		if !ok || got != "/var/lib/condor/job_queue/job_queue.log" {
+			t.Errorf("TEST_GUARDED_KNOB = %q (set=%v), want the guarded path", got, ok)
+		}
+	})
+	t.Run("hostname differs -> knob unset", func(t *testing.T) {
+		cfg, err := NewFromReader(strings.NewReader(fmt.Sprintf(tmpl, "other.example.org")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, ok := cfg.Get("TEST_GUARDED_KNOB"); ok {
+			t.Errorf("TEST_GUARDED_KNOB unexpectedly set to %q on a non-matching host", got)
+		}
+	})
+}


### PR DESCRIPTION
### Symptom

htcondordb wasn't finding `JOB_QUEUE_LOG`. It's set inside a hostname guard:

```conf
FULL_HOSTNAME_CHECK_AP43 = "$(FULL_HOSTNAME)" == "ap43.uw.osg-htc.org" || "$(FULL_HOSTNAME)" == "ospool-ap4043.chtc.wisc.edu"
if $INT(FULL_HOSTNAME_CHECK_AP43)
  JOB_QUEUE_LOG = /var/lib/condor/job_queue/job_queue.log
endif
```

The `if` silently evaluated false even on the matching host, so `JOB_QUEUE_LOG` was never set and htcondordb fell back to the default path.

### Cause

HTCondor's `$INT(name)` / `$REAL(name)` treat the argument as a **macro name**: look it up, expand its value, then interpret it as a number — first as a literal, and if that fails, by **evaluating it as a ClassAd expression** (`string_is_long_param` → `AssignExpr`+`EvalInteger`). The Go implementation only ran `strconv.ParseFloat` on the raw argument, so:

- it never looked up `FULL_HOSTNAME_CHECK_AP43` as a macro, and
- it never evaluated the boolean expression.

`$INT(...)` therefore errored; `expandMacrosWithFunctions` swallowed the error to `""`; `if ""` → false → block skipped.

### Fix

`$INT`/`$REAL` now: look up the argument as a (subsystem-scoped) macro name, expand `$(...)` in its value, try a numeric literal, then fall back to ClassAd-expression evaluation, coercing a boolean result to `1`/`0`. Matches HTCondor and the C++ `string_is_long_param` path.

Tests: boolean guard true/false, arithmetic, literal fast-path, real→int truncation, `$REAL` of an expression, and the end-to-end `if $INT(HOSTCHECK)` guarding a knob (set on the matching host, unset otherwise). Existing `$INT(3.14)`/`$INT($(NUM))` tests still pass; full config suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
