### PR TITLE
config: resolve FULL_HOSTNAME to the FQDN, not bare os.Hostname()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // ConfigOptions contains configuration parameters for creating a Config
@@ -279,10 +280,13 @@ func (c *Config) initBuiltins() {
 	c.Set("DAY", "86400")
 	c.Set("WEEK", "604800")
 
-	// Auto-detected values
-	hostname, _ := os.Hostname()
-	c.Set("HOSTNAME", strings.Split(hostname, ".")[0])
-	c.Set("FULL_HOSTNAME", hostname)
+	// Auto-detected values. FULL_HOSTNAME must be the fully-qualified name (as
+	// C++ HTCondor's get_local_fqdn produces), because configs routinely gate on
+	// it -- e.g. `"$(FULL_HOSTNAME)" == "host.example.org"`. os.Hostname() alone
+	// is often the short name, which would silently fail such comparisons.
+	short, fqdn := detectHostnames()
+	c.Set("HOSTNAME", short)
+	c.Set("FULL_HOSTNAME", fqdn)
 
 	// IP address detection
 	ipv4Addr, ipv6Addr, ipAddr := detectIPAddresses()
@@ -363,6 +367,66 @@ func (c *Config) initBuiltins() {
 // isWindows checks if running on Windows
 func isWindows() bool {
 	return os.PathSeparator == '\\'
+}
+
+// detectHostnames returns the short hostname and the fully-qualified domain
+// name, mirroring C++ HTCondor's init_local_hostname_impl: start from
+// os.Hostname(); if it carries no domain, resolve the canonical name via DNS;
+// then split the short name off before the first dot.
+func detectHostnames() (short, fqdn string) {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		return host, host
+	}
+	fqdn = host
+	// Only pay for a DNS lookup when the hostname is unqualified -- a dotted
+	// os.Hostname() is already the FQDN (matching the C++ "already has a dot"
+	// fast path).
+	if !strings.Contains(host, ".") {
+		if resolved := resolveFQDN(host); resolved != "" {
+			fqdn = resolved
+		}
+	}
+	return shortFromFQDN(fqdn), fqdn
+}
+
+// shortFromFQDN returns the first DNS label of a (possibly qualified) name --
+// "ap43.uw.osg-htc.org" -> "ap43", "ap43" -> "ap43".
+func shortFromFQDN(fqdn string) string {
+	if i := strings.IndexByte(fqdn, '.'); i >= 0 {
+		return fqdn[:i]
+	}
+	return fqdn
+}
+
+// resolveFQDN approximates getaddrinfo(AI_CANONNAME) for an unqualified host:
+// try the canonical (CNAME) name first, then the reverse-DNS name of a resolved
+// address. Returns "" if no qualified name can be found. Bounded by a short
+// timeout so config initialization never blocks on slow/absent DNS.
+func resolveFQDN(host string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	r := net.DefaultResolver
+
+	if cname, err := r.LookupCNAME(ctx, host); err == nil {
+		if c := strings.TrimSuffix(cname, "."); strings.Contains(c, ".") {
+			return c
+		}
+	}
+	if addrs, err := r.LookupHost(ctx, host); err == nil {
+		for _, addr := range addrs {
+			names, err := r.LookupAddr(ctx, addr)
+			if err != nil {
+				continue
+			}
+			for _, n := range names {
+				if name := strings.TrimSuffix(n, "."); strings.Contains(name, ".") {
+					return name
+				}
+			}
+		}
+	}
+	return ""
 }
 
 // detectIPAddresses detects IP addresses from network interfaces

--- a/config/hostname_test.go
+++ b/config/hostname_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShortFromFQDN(t *testing.T) {
+	cases := map[string]string{
+		"ap43.uw.osg-htc.org": "ap43",
+		"ap43":                "ap43",
+		"a.b":                 "a",
+		"":                    "",
+	}
+	for in, want := range cases {
+		if got := shortFromFQDN(in); got != want {
+			t.Errorf("shortFromFQDN(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestDetectHostnamesInvariants checks the split contract against the real host:
+// the short name carries no dot, and the FQDN's first label is the short name.
+func TestDetectHostnamesInvariants(t *testing.T) {
+	short, fqdn := detectHostnames()
+	if strings.Contains(short, ".") {
+		t.Errorf("short hostname %q unexpectedly contains a dot", short)
+	}
+	if short != shortFromFQDN(fqdn) {
+		t.Errorf("short %q is not the first label of fqdn %q", short, fqdn)
+	}
+}
+
+// TestFullHostnameGate is the reproduction of the reported failure: a config
+// that gates on `"$(FULL_HOSTNAME)" == "<fqdn>"`. With FULL_HOSTNAME set to a
+// bare short name the comparison silently failed; here we pin that once
+// FULL_HOSTNAME is a qualified name, an equality gate against it evaluates true.
+func TestFullHostnameGate(t *testing.T) {
+	// Drive the config directly with a known FULL_HOSTNAME so the test does not
+	// depend on the runner's DNS, exercising the same expansion + $INT path the
+	// real config uses.
+	txt := `FULL_HOSTNAME = ap43.uw.osg-htc.org
+HOSTCHECK = "$(FULL_HOSTNAME)" == "ap43.uw.osg-htc.org" || "$(FULL_HOSTNAME)" == "ospool-ap4043.chtc.wisc.edu"
+if $INT(HOSTCHECK)
+  TEST_GUARDED_KNOB = /var/lib/condor/job_queue/job_queue.log
+endif
+`
+	cfg, err := NewFromReader(strings.NewReader(txt))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := cfg.Get("TEST_GUARDED_KNOB")
+	if !ok || got != "/var/lib/condor/job_queue/job_queue.log" {
+		t.Errorf("TEST_GUARDED_KNOB = %q (set=%v); the FULL_HOSTNAME gate did not fire", got, ok)
+	}
+}


### PR DESCRIPTION
### Likely root cause of "htcondordb couldn't process the existing JOB_QUEUE_LOG config"

The config gates the path on the fully-qualified hostname:

```conf
FULL_HOSTNAME_CHECK_AP43 = "$(FULL_HOSTNAME)" == "ap43.uw.osg-htc.org" || "$(FULL_HOSTNAME)" == "ospool-ap4043.chtc.wisc.edu"
if $INT(FULL_HOSTNAME_CHECK_AP43)
  JOB_QUEUE_LOG = /var/lib/condor/job_queue/job_queue.log
endif
```

golang-htcondor set `FULL_HOSTNAME` to bare `os.Hostname()`, which on most hosts is the **short** name (`ap43`). So `"$(FULL_HOSTNAME)" == "ap43.uw.osg-htc.org"` was false, `$INT(...)` → 0, and the block was silently skipped — `JOB_QUEUE_LOG` fell back to its default and the file wasn't found.

### Fix

Resolve the FQDN like C++ HTCondor's `get_local_fqdn` / `init_local_hostname_impl`: start from `os.Hostname()`; if it carries no domain, resolve the canonical name via DNS (CNAME, then reverse-DNS of a resolved address); `HOSTNAME` is the first label. Bounded by a 2s timeout so config init never blocks on slow/absent DNS. A hostname that already contains a dot is used as-is (no DNS lookup — matching the C++ "already has a dot" fast path).

Tests: label-split cases, real-host invariants (short has no dot; it's the FQDN's first label), and the end-to-end `if $INT("$(FULL_HOSTNAME)" == ...)` gate firing when `FULL_HOSTNAME` is qualified. Full config suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
