### PR TITLE
classadlog: don't consume a partial (unterminated) trailing line

### DIFF
--- a/classadlog/parser.go
+++ b/classadlog/parser.go
@@ -2,6 +2,7 @@ package classadlog
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -85,7 +86,7 @@ func (p *Parser) ReadEntry() (*LogEntry, error) {
 			// schedd appends a transaction incrementally). Do NOT consume or parse it:
 			// return EOF and leave the bytes to be re-read, complete, on the next Open.
 			// Any other error is real.
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil, io.EOF
 			}
 			return nil, err

--- a/classadlog/parser.go
+++ b/classadlog/parser.go
@@ -12,8 +12,9 @@ import (
 type Parser struct {
 	filename   string
 	file       *os.File
-	scanner    *bufio.Scanner
-	nextOffset int64
+	reader     *bufio.Reader
+	nextOffset int64 // byte offset where the next unread line begins
+	consumed   int64 // bytes of complete (newline-terminated) lines read since Open
 	lastEntry  *LogEntry
 }
 
@@ -36,7 +37,6 @@ func (p *Parser) Open() error {
 	}
 
 	p.file = f
-	p.scanner = bufio.NewScanner(f)
 
 	// If we have a saved offset, seek to it
 	if p.nextOffset > 0 {
@@ -47,6 +47,8 @@ func (p *Parser) Open() error {
 		}
 	}
 
+	p.reader = bufio.NewReader(f)
+	p.consumed = 0
 	return nil
 }
 
@@ -56,14 +58,16 @@ func (p *Parser) Close() error {
 		return nil
 	}
 
-	// Save current offset before closing
-	if offset, err := p.file.Seek(0, io.SeekCurrent); err == nil {
-		p.nextOffset = offset
-	}
+	// Advance the resume offset by the bytes of the COMPLETE lines we consumed.
+	// A partial (not-yet-newline-terminated) trailing line is deliberately not
+	// counted, so the next Open re-reads it once the schedd finishes writing it --
+	// rather than reading past it (skipping the op) or parsing it truncated.
+	p.nextOffset += p.consumed
 
 	err := p.file.Close()
 	p.file = nil
-	p.scanner = nil
+	p.reader = nil
+	p.consumed = 0
 	return err
 }
 
@@ -74,27 +78,33 @@ func (p *Parser) ReadEntry() (*LogEntry, error) {
 		return nil, fmt.Errorf("file not open")
 	}
 
-	if !p.scanner.Scan() {
-		if err := p.scanner.Err(); err != nil {
+	for {
+		raw, err := p.reader.ReadString('\n')
+		if err != nil {
+			// A trailing chunk without a newline is a partial write in progress (the
+			// schedd appends a transaction incrementally). Do NOT consume or parse it:
+			// return EOF and leave the bytes to be re-read, complete, on the next Open.
+			// Any other error is real.
+			if err == io.EOF {
+				return nil, io.EOF
+			}
 			return nil, err
 		}
-		return nil, io.EOF
+		// A complete, newline-terminated line: count its bytes toward the resume offset.
+		p.consumed += int64(len(raw))
+
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue // skip blank lines and comments
+		}
+
+		entry, perr := p.parseLine(line)
+		if perr != nil {
+			return nil, fmt.Errorf("failed to parse line %q: %w", line, perr)
+		}
+		p.lastEntry = entry
+		return entry, nil
 	}
-
-	line := strings.TrimSpace(p.scanner.Text())
-
-	// Skip empty lines and comments
-	if line == "" || strings.HasPrefix(line, "#") {
-		return p.ReadEntry() // Recursive call to get next non-empty line
-	}
-
-	entry, err := p.parseLine(line)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse line %q: %w", line, err)
-	}
-
-	p.lastEntry = entry
-	return entry, nil
 }
 
 // parseLine parses a single line into a LogEntry

--- a/classadlog/partial_line_test.go
+++ b/classadlog/partial_line_test.go
@@ -40,7 +40,7 @@ func TestPartialTrailingLineNotConsumed(t *testing.T) {
 	// A complete op, then a partial SetAttribute (op 103) with no value + no newline,
 	// exactly like the reported "103 16257.1830 RecentB".
 	complete := "103 1.0 Owner \"alice\"\n"
-	if err := os.WriteFile(path, []byte(complete+"103 1.0 RecentB"), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(complete+"103 1.0 RecentB"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -57,7 +57,7 @@ func TestPartialTrailingLineNotConsumed(t *testing.T) {
 	}
 
 	// The schedd finishes the line (value + newline) and appends another op.
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // G304: test temp path
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/classadlog/partial_line_test.go
+++ b/classadlog/partial_line_test.go
@@ -1,0 +1,79 @@
+package classadlog
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// drainOpen reads every entry the parser can currently produce, returning them.
+// It mirrors one poll cycle: Open (seek to the saved offset), read to EOF, Close
+// (which finalizes the resume offset).
+func drainOpen(t *testing.T, p *Parser) []*LogEntry {
+	t.Helper()
+	if err := p.Open(); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+	var out []*LogEntry
+	for {
+		e, err := p.ReadEntry()
+		if errors.Is(err, io.EOF) {
+			return out
+		}
+		if err != nil {
+			t.Fatalf("ReadEntry: %v", err)
+		}
+		out = append(out, e)
+	}
+}
+
+// TestPartialTrailingLineNotConsumed reproduces a poll catching the schedd
+// mid-write: a transaction whose final line has been partially written (no
+// trailing newline yet). The parser must not error on it, must not consume it,
+// and must read it in full once the newline arrives -- with nothing lost.
+func TestPartialTrailingLineNotConsumed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "job_queue.log")
+
+	// A complete op, then a partial SetAttribute (op 103) with no value + no newline,
+	// exactly like the reported "103 16257.1830 RecentB".
+	complete := "103 1.0 Owner \"alice\"\n"
+	if err := os.WriteFile(path, []byte(complete+"103 1.0 RecentB"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewParser(path)
+	got := drainOpen(t, p)
+	if len(got) != 1 {
+		t.Fatalf("first poll: got %d entries, want 1 (the partial line must be withheld)", len(got))
+	}
+	if got[0].OpType != OpSetAttribute || got[0].Key != "1.0" || got[0].Name != "Owner" {
+		t.Fatalf("first entry = %+v, want SetAttribute 1.0 Owner", got[0])
+	}
+	if p.GetNextOffset() != int64(len(complete)) {
+		t.Fatalf("offset after partial = %d, want %d (start of the partial line)", p.GetNextOffset(), len(complete))
+	}
+
+	// The schedd finishes the line (value + newline) and appends another op.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("lockReads 42\n103 1.0 JobStatus 2\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	got = drainOpen(t, p)
+	if len(got) != 2 {
+		t.Fatalf("second poll: got %d entries, want 2 (the completed line + the new op)", len(got))
+	}
+	if got[0].Name != "RecentBlockReads" || got[0].Value != "42" {
+		t.Errorf("completed line = %+v, want RecentBlockReads=42 (partial+rest joined)", got[0])
+	}
+	if got[1].Name != "JobStatus" {
+		t.Errorf("second entry = %+v, want JobStatus", got[1])
+	}
+}


### PR DESCRIPTION
### The log spam (and a latent data-loss bug)

Schedd-sync logged repeated warnings like:

```
job_queue.log poll failed err="failed to parse line \"103 16257.1830 RecentB\": SetAttribute requires key, name, and value"
```

The parser used `bufio.Scanner`, which returns the final line even when it has **no trailing newline**. The schedd appends a transaction incrementally, so a poll can catch a half-written line (`103 <key> RecentB…` with the value not flushed yet) and fail to parse it.

Beyond the noise, the offset was tracked with `f.Seek(SeekCurrent)`. A `bufio.Scanner` reads ahead in 64KB chunks, so that offset points *past* the lines actually consumed — meaning the completed line could be **skipped on the next poll** (a lost `SetAttribute`).

### Fix

Read with `bufio.Reader.ReadString('\n')`: only newline-terminated lines are parsed and counted toward the resume offset; a trailing chunk without a newline returns `io.EOF` and is left in place, re-read complete on the next `Open`. Also removes the scanner's 64KB per-line cap (large ClassAd values).

Test reproduces the reported case: a partial `103 1.0 RecentB` is withheld (no error, offset parked at its start), then the completed `…lockReads 42\n` plus a following op are read in full — nothing lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
