### PR TITLE
deps: bump classad v0.8.0 -> v0.16.7 across all modules

### DIFF
--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -7,7 +7,7 @@ replace github.com/bbockelm/golang-htcondor => ../..
 require github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 
 require (
-	github.com/PelicanPlatform/classad v0.8.0 // indirect
+	github.com/PelicanPlatform/classad v0.16.7 // indirect
 	github.com/bbockelm/cedar v0.6.3 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect

--- a/examples/basic/go.sum
+++ b/examples/basic/go.sum
@@ -1,5 +1,5 @@
-github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
-github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
+github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
+github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
 github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
 github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=

--- a/examples/file_transfer_demo/go.mod
+++ b/examples/file_transfer_demo/go.mod
@@ -5,7 +5,7 @@ go 1.25.7
 replace github.com/bbockelm/golang-htcondor => ../..
 
 require (
-	github.com/PelicanPlatform/classad v0.8.0
+	github.com/PelicanPlatform/classad v0.16.7
 	github.com/bbockelm/cedar v0.6.3
 	github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 )

--- a/examples/file_transfer_demo/go.sum
+++ b/examples/file_transfer_demo/go.sum
@@ -1,5 +1,5 @@
-github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
-github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
+github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
+github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
 github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
 github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=

--- a/examples/param_defaults_demo/go.mod
+++ b/examples/param_defaults_demo/go.mod
@@ -7,6 +7,6 @@ replace github.com/bbockelm/golang-htcondor => ../..
 require github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 
 require (
-	github.com/PelicanPlatform/classad v0.8.0 // indirect
+	github.com/PelicanPlatform/classad v0.16.7 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/examples/param_defaults_demo/go.sum
+++ b/examples/param_defaults_demo/go.sum
@@ -1,4 +1,4 @@
-github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
-github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
+github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
+github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/examples/queue_demo/go.mod
+++ b/examples/queue_demo/go.mod
@@ -12,7 +12,7 @@ require (
 )
 
 require (
-	github.com/PelicanPlatform/classad v0.8.0 // indirect
+	github.com/PelicanPlatform/classad v0.16.7 // indirect
 	github.com/bbockelm/cedar v0.6.3 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect

--- a/examples/queue_demo/go.sum
+++ b/examples/queue_demo/go.sum
@@ -1,5 +1,5 @@
-github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
-github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
+github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
+github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
 github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
 github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=

--- a/examples/security_config/go.mod
+++ b/examples/security_config/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/PelicanPlatform/classad v0.8.0 // indirect
+	github.com/PelicanPlatform/classad v0.16.7 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/security_config/go.sum
+++ b/examples/security_config/go.sum
@@ -1,5 +1,5 @@
-github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
-github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
+github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
+github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
 github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
 github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=

--- a/examples/submit_demo/go.mod
+++ b/examples/submit_demo/go.mod
@@ -5,7 +5,7 @@ go 1.25.7
 require github.com/bbockelm/golang-htcondor v0.0.0
 
 require (
-	github.com/PelicanPlatform/classad v0.8.0 // indirect
+	github.com/PelicanPlatform/classad v0.16.7 // indirect
 	github.com/bbockelm/cedar v0.6.3 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect

--- a/examples/submit_demo/go.sum
+++ b/examples/submit_demo/go.sum
@@ -1,5 +1,5 @@
-github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
-github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
+github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
+github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
 github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
 github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bbockelm/golang-htcondor
 go 1.25.7
 
 require (
-	github.com/PelicanPlatform/classad v0.8.0
+	github.com/PelicanPlatform/classad v0.16.7
 	github.com/bbockelm/cedar v0.6.3
 	github.com/bbockelm/gosssd v0.0.1
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
@@ -14,7 +14,7 @@ require (
 )
 
 require (
-	github.com/PelicanPlatform/classad/collections v0.8.0
+	github.com/PelicanPlatform/classad/collections v0.16.7
 	github.com/glebarez/go-sqlite v1.21.2
 	github.com/pressly/goose/v3 v3.27.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
-github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/PelicanPlatform/classad/collections v0.8.0 h1:qlNkYij8O52beqb0ekrYKrCT1iirnzBY2y3hkfxXCdg=
-github.com/PelicanPlatform/classad/collections v0.8.0/go.mod h1:djT/JhGuLcMnVyXOsdiniPzZC6NaxQz8ZHTkffYZtNY=
+github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
+github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
+github.com/PelicanPlatform/classad/collections v0.16.7 h1:WBpuw2mTUCmpOgd3kQFkKt14FWMXnXDrquurdytzyLs=
+github.com/PelicanPlatform/classad/collections v0.16.7/go.mod h1:djT/JhGuLcMnVyXOsdiniPzZC6NaxQz8ZHTkffYZtNY=
 github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5UCbeKB4UQ4=
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
 github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=

--- a/localcredmon/go.mod
+++ b/localcredmon/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/PelicanPlatform/classad v0.8.0 // indirect
+	github.com/PelicanPlatform/classad v0.16.7 // indirect
 	github.com/bbockelm/cedar v0.6.3 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/localcredmon/go.sum
+++ b/localcredmon/go.sum
@@ -1,5 +1,5 @@
-github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
-github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
+github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
+github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
 github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
 github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=

--- a/webapi/go.mod
+++ b/webapi/go.mod
@@ -3,7 +3,7 @@ module github.com/bbockelm/golang-htcondor/webapi
 go 1.25.7
 
 require (
-	github.com/PelicanPlatform/classad v0.8.0
+	github.com/PelicanPlatform/classad v0.16.7
 	github.com/bbockelm/cedar v0.6.3
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/glebarez/sqlite v1.11.0
@@ -17,7 +17,7 @@ require (
 )
 
 require (
-	github.com/PelicanPlatform/classad/collections v0.8.0
+	github.com/PelicanPlatform/classad/collections v0.16.7
 	github.com/hashicorp/yamux v0.1.2
 	github.com/pressly/goose/v3 v3.27.2
 	github.com/prometheus/client_golang v1.23.2

--- a/webapi/go.sum
+++ b/webapi/go.sum
@@ -39,10 +39,10 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/PelicanPlatform/classad v0.8.0 h1:U2CV/k2iE+8DkwbApTfOb8ue76/E/m0UBXlmUKwyQzU=
-github.com/PelicanPlatform/classad v0.8.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/PelicanPlatform/classad/collections v0.8.0 h1:qlNkYij8O52beqb0ekrYKrCT1iirnzBY2y3hkfxXCdg=
-github.com/PelicanPlatform/classad/collections v0.8.0/go.mod h1:djT/JhGuLcMnVyXOsdiniPzZC6NaxQz8ZHTkffYZtNY=
+github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
+github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
+github.com/PelicanPlatform/classad/collections v0.16.7 h1:WBpuw2mTUCmpOgd3kQFkKt14FWMXnXDrquurdytzyLs=
+github.com/PelicanPlatform/classad/collections v0.16.7/go.mod h1:djT/JhGuLcMnVyXOsdiniPzZC6NaxQz8ZHTkffYZtNY=
 github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5UCbeKB4UQ4=
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=


### PR DESCRIPTION
Brings golang-htcondor's `classad`/`dbrpc` up to the version **htcondordb serves (v0.16.7)**, so a dbrpc client here can speak the current wire protocol and reach the newer features (time-travel `opQueryAsOf`, bucketed aggregates). This is the **prerequisite** for wiring htcondordb-backed tools into the htcondor-api MCP — the old v0.8.0 client lacked `QueryAsOfTable` and predated 8 minor versions of dbrpc opcode/framing changes, so it couldn't reliably talk to a v0.16.7 server.

### The good news: it's a clean bump
The v0.8.0 → v0.16.7 jump is **API-backward-compatible** for golang-htcondor's usage — **no source changes**, only dependency versions. Root + webapi **build, vet, and test clean** against v0.16.7.

`make tidy-all` applied across every module (root, webapi, localcredmon, 6 examples) — all now consistent at v0.16.7.

### The two failing tests are pre-existing / environmental (not classad)
Both fail **identically on the base** with v0.8.0:
- `webapi/httpserver TestGetDefaultDBPath` — this host's HTCondor `LOCAL_DIR` default.
- `sharedport TestListenerCloseWaitsForHandlers` — the macOS 104-char unix-socket `sun_path` limit (the test's `t.TempDir()` path lands right at 104 chars). Flaky by path length; the base fails too once the random temp suffix is long enough.

Neither touches classad, and the `go.mod` diff shows **only** `classad`/`collections` changed — no other dependency moved.
