### PR TITLE
deps: bump cedar v0.6.3 -> v0.6.6 across all modules

### DIFF
--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -8,7 +8,7 @@ require github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7 // indirect
-	github.com/bbockelm/cedar v0.6.3 // indirect
+	github.com/bbockelm/cedar v0.6.6 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/basic/go.sum
+++ b/examples/basic/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
-github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
+github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/file_transfer_demo/go.mod
+++ b/examples/file_transfer_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/bbockelm/golang-htcondor => ../..
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7
-	github.com/bbockelm/cedar v0.6.3
+	github.com/bbockelm/cedar v0.6.6
 	github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/file_transfer_demo/go.sum
+++ b/examples/file_transfer_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
-github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
+github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/queue_demo/go.mod
+++ b/examples/queue_demo/go.mod
@@ -13,7 +13,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7 // indirect
-	github.com/bbockelm/cedar v0.6.3 // indirect
+	github.com/bbockelm/cedar v0.6.6 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/queue_demo/go.sum
+++ b/examples/queue_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
-github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
+github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/security_config/go.mod
+++ b/examples/security_config/go.mod
@@ -3,7 +3,7 @@ module github.com/bbockelm/golang-htcondor/examples/security_config
 go 1.25.7
 
 require (
-	github.com/bbockelm/cedar v0.6.3
+	github.com/bbockelm/cedar v0.6.6
 	github.com/bbockelm/golang-htcondor v0.0.0-20251113012241-ab2a8efb0537
 )
 

--- a/examples/security_config/go.sum
+++ b/examples/security_config/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
-github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
+github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/submit_demo/go.mod
+++ b/examples/submit_demo/go.mod
@@ -6,7 +6,7 @@ require github.com/bbockelm/golang-htcondor v0.0.0
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7 // indirect
-	github.com/bbockelm/cedar v0.6.3 // indirect
+	github.com/bbockelm/cedar v0.6.6 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/submit_demo/go.sum
+++ b/examples/submit_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
-github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
+github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7
-	github.com/bbockelm/cedar v0.6.3
+	github.com/bbockelm/cedar v0.6.6
 	github.com/bbockelm/gosssd v0.0.1
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/PelicanPlatform/classad/collections v0.16.7 h1:WBpuw2mTUCmpOgd3kQFkKt
 github.com/PelicanPlatform/classad/collections v0.16.7/go.mod h1:djT/JhGuLcMnVyXOsdiniPzZC6NaxQz8ZHTkffYZtNY=
 github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5UCbeKB4UQ4=
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
-github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
-github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
+github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=

--- a/localcredmon/go.mod
+++ b/localcredmon/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7 // indirect
-	github.com/bbockelm/cedar v0.6.3 // indirect
+	github.com/bbockelm/cedar v0.6.6 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect

--- a/localcredmon/go.sum
+++ b/localcredmon/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
-github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
+github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/webapi/go.mod
+++ b/webapi/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7
-	github.com/bbockelm/cedar v0.6.3
+	github.com/bbockelm/cedar v0.6.6
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/glebarez/sqlite v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/webapi/go.sum
+++ b/webapi/go.sum
@@ -48,8 +48,8 @@ github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQ
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/bbockelm/cedar v0.6.3 h1:cxfoN/r5g/LpQmlYXvEqJ6kYgbF1icitiVwA9wcMPvw=
-github.com/bbockelm/cedar v0.6.3/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
+github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
Bumps `github.com/bbockelm/cedar` from v0.6.3 to v0.6.6 in every module (root, localcredmon, webapi, and the examples) via `make tidy-all`.

Picks up the cedar changes since v0.6.3 — notably the session-resumption fallback (v0.6.4/v0.6.5, so a failed resumption falls back to a full auth instead of erroring) plus v0.6.6.

Deps-only; build, vet, and the daemon + root suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)