### PR TITLE
daemon: capture process stdout/stderr into the log under condor_master

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -122,6 +122,14 @@ func New(opts Options) (*Daemon, error) {
 			return nil, fmt.Errorf("daemon: building logger: %w", err)
 		}
 	}
+	// Under condor_master our stdout/stderr are wired to /dev/null, so anything that
+	// escapes the logger -- a panic stack, a library writing to stderr, a bare fmt.Print
+	// from a misconfiguration path -- vanishes. As soon as the log file exists, redirect
+	// the process's stdout/stderr fds into it (and re-point on rotation) so that output is
+	// captured. No-op when logging to a std stream or on a non-unix platform.
+	if UnderCondorMaster() {
+		captureStdoutStderr(logger)
+	}
 	switch {
 	case drop.dropped:
 		logger.Info(logging.DestinationGeneral, "dropped privileges", "euid", drop.uid, "egid", drop.gid)

--- a/daemon/stdio_other.go
+++ b/daemon/stdio_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package daemon
+
+import "github.com/bbockelm/golang-htcondor/logging"
+
+// captureStdoutStderr is a no-op on non-unix platforms (no dup2). Go HTCondor daemons run
+// under condor_master on unix; this keeps the package buildable elsewhere.
+func captureStdoutStderr(*logging.Logger) {}

--- a/daemon/stdio_unix.go
+++ b/daemon/stdio_unix.go
@@ -1,0 +1,39 @@
+//go:build unix
+
+package daemon
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/bbockelm/golang-htcondor/logging"
+)
+
+// captureStdoutStderr points the process's stdout(1) and stderr(2) file descriptors at the
+// logger's current log file, and re-points them whenever the log rotates. This captures
+// output that bypasses the structured logger -- panic stacks (the runtime writes them to
+// fd 2 directly), a dependency writing to stderr, or a bare fmt.Print on an early
+// misconfiguration path -- which condor_master otherwise sends to /dev/null.
+//
+// It is a no-op when the logger writes to a std stream already (File() == nil), avoiding a
+// self-referential redirect. dup2 duplicates onto the real fds, so it also covers any
+// child or C library that inherits and writes fd 1/2, not just Go's os.Stdout/os.Stderr.
+func captureStdoutStderr(logger *logging.Logger) {
+	redirect := func(f *os.File) {
+		if f == nil {
+			return
+		}
+		fd := int(f.Fd())
+		_ = unix.Dup2(fd, int(os.Stdout.Fd()))
+		_ = unix.Dup2(fd, int(os.Stderr.Fd()))
+	}
+
+	f := logger.File()
+	if f == nil {
+		return // logging to stdout/stderr already, or the file failed to open
+	}
+	redirect(f)
+	logger.OnRotate(redirect) // follow the file across rotations
+	logger.Info(logging.DestinationGeneral, "captured stdout/stderr into the log file", "path", f.Name())
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -99,6 +99,35 @@ type Logger struct {
 	rotating     atomic.Int32                // Flag to indicate rotation in progress (0 or 1)
 	maintWg      sync.WaitGroup              // WaitGroup for maintenance goroutine
 	maintRunning atomic.Bool                 // Indicates if maintenance is running
+
+	rotMu    sync.Mutex       // guards onRotate
+	onRotate []func(*os.File) // called with the new file after each rotation/reopen
+}
+
+// File returns the current log output file, or nil when logging to a std stream
+// (stdout/stderr) or when open failed. The file changes on rotation, so a caller that
+// holds onto it (e.g. redirecting process stdout/stderr into the log) must also register
+// OnRotate to follow the new file.
+func (l *Logger) File() *os.File { return l.logFile.Load() }
+
+// OnRotate registers fn to be invoked with the new log file each time the log rotates or
+// is reopened. Used to re-point an external redirection (process stdout/stderr) at the new
+// file so it does not keep writing into the rotated-away one. fn must not block.
+func (l *Logger) OnRotate(fn func(*os.File)) {
+	l.rotMu.Lock()
+	l.onRotate = append(l.onRotate, fn)
+	l.rotMu.Unlock()
+}
+
+// fireRotate notifies OnRotate subscribers of the new file after a rotation/reopen.
+func (l *Logger) fireRotate(f *os.File) {
+	l.rotMu.Lock()
+	fns := make([]func(*os.File), len(l.onRotate))
+	copy(fns, l.onRotate)
+	l.rotMu.Unlock()
+	for _, fn := range fns {
+		fn(f)
+	}
 }
 
 // Default configuration values
@@ -828,6 +857,7 @@ func (l *Logger) rotateLogIfNeeded() error {
 	// Update file handle and reset size atomically
 	l.logFile.Store(f)
 	l.currentSize.Store(0)
+	l.fireRotate(f)
 
 	// Rebuild through the per-destination filtering handler (bound to the live level
 	// snapshot) so post-rotation direct-slog calls stay filtered.
@@ -932,6 +962,7 @@ func (l *Logger) reopenLogFile() error {
 	if oldFile != nil {
 		_ = oldFile.Close() // Ignore error, old file is being replaced
 	}
+	l.fireRotate(f)
 
 	// Reset size to current file size
 	l.currentSize.Store(stat.Size())

--- a/logging/rotate_hook_test.go
+++ b/logging/rotate_hook_test.go
@@ -1,0 +1,42 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOnRotateFiresWithNewFile verifies File() returns the live log file and OnRotate is
+// called with the new file after a rotation -- the contract the daemon's stdout/stderr
+// capture relies on to follow the log across rotations.
+func TestOnRotateFiresWithNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	l, err := New(&Config{OutputPath: path, MaxLogSize: 200, MaxNumLogs: 2, DefaultLevel: VerbosityInfo, SkipGlobalInstall: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l.File() == nil {
+		t.Fatal("File() is nil for a file-backed logger")
+	}
+	orig := l.File()
+
+	var gotName string
+	var calls int
+	l.OnRotate(func(f *os.File) { calls++; gotName = f.Name() })
+
+	// Write enough to trip size-based rotation (MaxLogSize=200).
+	for i := 0; i < 50; i++ {
+		l.Info(DestinationGeneral, "some log line to grow the file past the rotation threshold")
+	}
+
+	if calls == 0 {
+		t.Fatal("OnRotate never fired despite exceeding MaxLogSize")
+	}
+	if gotName != path {
+		t.Errorf("OnRotate new file = %q, want the active path %q", gotName, path)
+	}
+	if l.File() == orig {
+		t.Error("File() still returns the pre-rotation file")
+	}
+}


### PR DESCRIPTION
condor_master wires a managed daemon's stdout/stderr to `/dev/null`, so anything that escapes the structured logger — a panic stack (the runtime writes it to fd 2 directly), a dependency writing to stderr, a bare `fmt.Print` on an early misconfiguration path — disappears. A misconfigured daemon then looks like it died silently (exactly what happened here).

As soon as the log file exists, `New()` (when `UnderCondorMaster()`) `dup2`'s the process **stdout(1)/stderr(2) fds** onto the log file, and re-points them on rotation so they follow the active file. Duplicating the real fds also covers inherited / C-library writers, not just Go's `os.Stdout`/`os.Stderr`. No-op when logging to a std stream (`File()==nil`) or on non-unix (build-tagged stub).

Two small logging hooks enable it without exposing internals broadly: `Logger.File()` (current log file) and `Logger.OnRotate(fn)` (fired with the new file on rotation/reopen) — the latter unit-tested. Generic `daemon` package; all Go HTCondor daemons benefit. Builds + logging & daemon suites green; non-unix stub cross-compiles.

Independent of #154 (startup/drain logging) — both cut from `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)