### PR TITLE
htcondor: helpers to locate a peer daemon by its address file

### DIFF
--- a/locate.go
+++ b/locate.go
@@ -1,0 +1,109 @@
+// Package htcondor provides a Go client library for HTCondor. This file adds helpers for
+// locating a peer daemon by its address file.
+package htcondor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bbockelm/golang-htcondor/config"
+)
+
+// AddressFilePath returns where subsys writes its address file: the <SUBSYS>_ADDRESS_FILE
+// config value if set, otherwise $(LOG)/.<subsys>_address (the HTCondor default). It
+// returns "" when neither is resolvable (no override and LOG unset). subsys is the
+// upper-case subsystem name (e.g. "HTCONDORDB", "COLLECTOR").
+//
+// A DaemonCore daemon writes its current contact address to this file as a single-line
+// sinful string. That address is NOT stable: under shared port it carries a per-run socket
+// token that changes every time condor_master restarts the daemon, so a client that caches
+// the address once goes stale on restart. Pair this with FileAddressResolver so a
+// reconnecting client re-reads the file and follows a restarted daemon automatically.
+func AddressFilePath(cfg *config.Config, subsys string) string {
+	if v, ok := cfg.Get(subsys + "_ADDRESS_FILE"); ok {
+		if p := strings.TrimSpace(v); p != "" {
+			return p
+		}
+	}
+	if v, ok := cfg.Get("LOG"); ok {
+		if logDir := strings.TrimSpace(v); logDir != "" {
+			return filepath.Join(logDir, "."+strings.ToLower(subsys)+"_address")
+		}
+	}
+	return ""
+}
+
+// ReadAddressFile returns the first non-empty line of an HTCondor address file: a sinful
+// string, possibly angle-bracket wrapped (cedar's addresses.ParseSinful accepts either
+// form, and ConnectAndAuthenticate takes it as-is).
+func ReadAddressFile(path string) (string, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path is an operator-configured address-file location from HTCondor config, not user input
+
+	if err != nil {
+		return "", fmt.Errorf("reading address file %s: %w", path, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if s := strings.TrimSpace(line); s != "" {
+			return s, nil
+		}
+	}
+	return "", fmt.Errorf("address file %s is empty", path)
+}
+
+// FileAddressResolver returns a function that re-reads path (via ReadAddressFile) on every
+// call. Give it to a client that reconnects -- e.g. a connection pool that re-dials on
+// failure -- so each reconnect picks up the daemon's current address instead of a cached,
+// possibly-restarted-away one. A transient read failure surfaces to the caller (which
+// should back off and retry) rather than yielding a stale address.
+func FileAddressResolver(path string) func() (string, error) {
+	return func() (string, error) { return ReadAddressFile(path) }
+}
+
+// LocalDaemonAddress resolves subsys's address for a peer using the standard knobs, and
+// returns a resolver plus a one-line description of the source (for logging). On each call
+// the resolver prefers the daemon's address file (AddressFilePath) when that file is
+// present and readable -- so a co-located daemon is followed across restarts -- and
+// otherwise falls back to the static <SUBSYS>_HOST knob (e.g. a daemon on another host with
+// no local address file). It errors at construction only when neither a file path nor a
+// host is configured; a per-call file-read error still falls back to <SUBSYS>_HOST if one
+// is set, else surfaces so the caller can retry.
+//
+// A caller with its own knob names (e.g. a collector using COLLECTOR_DB_HOST /
+// COLLECTOR_DB_ADDRESS_FILE rather than the <SUBSYS>_* convention) should instead compose
+// AddressFilePath / FileAddressResolver directly with its own precedence.
+func LocalDaemonAddress(cfg *config.Config, subsys string) (func() (string, error), string, error) {
+	path := AddressFilePath(cfg, subsys)
+	host := ""
+	if v, ok := cfg.Get(subsys + "_HOST"); ok {
+		host = strings.TrimSpace(v)
+	}
+	if path == "" && host == "" {
+		return nil, "", fmt.Errorf("cannot locate %s: set %s_ADDRESS_FILE or %s_HOST (or LOG so $(LOG)/.%s_address resolves)",
+			subsys, subsys, subsys, strings.ToLower(subsys))
+	}
+	source := describeSource(path, host)
+	resolve := func() (string, error) {
+		if path != "" {
+			if addr, err := ReadAddressFile(path); err == nil {
+				return addr, nil
+			} else if host == "" {
+				return "", err // no fallback; let the caller retry
+			}
+		}
+		return host, nil
+	}
+	return resolve, source, nil
+}
+
+func describeSource(path, host string) string {
+	switch {
+	case path != "" && host != "":
+		return "address file " + path + " (fallback " + host + ")"
+	case path != "":
+		return "address file " + path
+	default:
+		return host
+	}
+}

--- a/locate_test.go
+++ b/locate_test.go
@@ -1,0 +1,98 @@
+package htcondor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bbockelm/golang-htcondor/config"
+)
+
+func cfgFrom(t *testing.T, kv map[string]string) *config.Config {
+	t.Helper()
+	dir := t.TempDir()
+	var b strings.Builder
+	for k, v := range kv {
+		b.WriteString(k + " = " + v + "\n")
+	}
+	p := filepath.Join(dir, "condor_config")
+	if err := os.WriteFile(p, []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CONDOR_CONFIG", p)
+	c, err := config.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestAddressFilePath(t *testing.T) {
+	// Explicit override wins.
+	c := cfgFrom(t, map[string]string{"HTCONDORDB_ADDRESS_FILE": "/custom/path", "LOG": "/var/log/condor"})
+	if got := AddressFilePath(c, "HTCONDORDB"); got != "/custom/path" {
+		t.Errorf("override: got %q", got)
+	}
+	// Default from LOG, lower-cased subsys.
+	c = cfgFrom(t, map[string]string{"LOG": "/var/log/condor"})
+	if got, want := AddressFilePath(c, "HTCONDORDB"), "/var/log/condor/.htcondordb_address"; got != want {
+		t.Errorf("default: got %q want %q", got, want)
+	}
+}
+
+func TestReadAddressFileAndResolver(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".htcondordb_address")
+	if err := os.WriteFile(p, []byte("\n<127.0.0.1:9618?sock=abc>\nextra\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadAddressFile(p)
+	if err != nil || got != "<127.0.0.1:9618?sock=abc>" {
+		t.Fatalf("ReadAddressFile = %q, %v", got, err)
+	}
+	// Resolver re-reads: rewrite reflects on the next call (the restart case).
+	resolve := FileAddressResolver(p)
+	if err := os.WriteFile(p, []byte("<127.0.0.1:9618?sock=NEW>\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := resolve(); v != "<127.0.0.1:9618?sock=NEW>" {
+		t.Fatalf("resolver did not re-read: %q", v)
+	}
+	if _, err := ReadAddressFile(filepath.Join(dir, "gone")); err == nil {
+		t.Error("missing file should error")
+	}
+}
+
+func TestLocalDaemonAddress(t *testing.T) {
+	dir := t.TempDir()
+	af := filepath.Join(dir, ".htcondordb_address")
+
+	// File present -> file preferred over the host fallback.
+	if err := os.WriteFile(af, []byte("<file-addr>\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c := cfgFrom(t, map[string]string{"HTCONDORDB_ADDRESS_FILE": af, "HTCONDORDB_HOST": "host-addr:9618"})
+	resolve, _, err := LocalDaemonAddress(c, "HTCONDORDB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := resolve(); v != "<file-addr>" {
+		t.Errorf("file present: got %q want <file-addr>", v)
+	}
+	// File missing -> fall back to host.
+	_ = os.Remove(af)
+	if v, _ := resolve(); v != "host-addr:9618" {
+		t.Errorf("file missing: got %q want host fallback", v)
+	}
+	// Host only (no LOG, no address file) -> host.
+	c = cfgFrom(t, map[string]string{"HTCONDORDB_HOST": "only-host:9618"})
+	resolve, _, err = LocalDaemonAddress(c, "HTCONDORDB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := resolve(); v != "only-host:9618" {
+		t.Errorf("host only: got %q", v)
+	}
+}


### PR DESCRIPTION
A DaemonCore daemon writes its current sinful string to `$(LOG)/.<subsys>_address` (overridable via `<SUBSYS>_ADDRESS_FILE`). Under shared port that address carries a per-run socket token that **changes on every condor_master restart**, so a client that caches it once goes stale — the bug behind the collector's `connection reset by peer` loop.

This pushes the mechanics down into golang-htcondor, since the collector's db-address dial and htcondordb-cli's `locateDaemon` had each reimplemented them:

- `AddressFilePath(cfg, subsys)` — `<SUBSYS>_ADDRESS_FILE` or `$(LOG)/.<subsys>_address`
- `ReadAddressFile(path)` — first non-empty line (a sinful string, bracket-tolerant)
- `FileAddressResolver(path)` — re-reads on **every** call, so a reconnecting client follows a restarted daemon
- `LocalDaemonAddress(cfg, subsys)` — file-preferred, `<SUBSYS>_HOST` fallback (the common convention)

A caller with non-standard knob names (a collector using `COLLECTOR_DB_*`) composes the primitives with its own precedence. Follow-ups will refactor the collector (revising #55 there) and dedup htcondordb-cli's `locateDaemon` onto these. Tests cover path convention, first-line/re-read, and file-preferred→host fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)