### PR TITLE
security: wire the privileged credential reader into daemon client configs

### DIFF
--- a/credential_reader.go
+++ b/credential_reader.go
@@ -3,9 +3,18 @@ package htcondor
 import (
 	"fmt"
 	"io"
+	"os"
 	"sync"
 
+	"github.com/bbockelm/cedar/security"
 	"github.com/bbockelm/golang-htcondor/droppriv"
+)
+
+// CredentialCache satisfies cedar's credential-reading hooks: ReadCredential for files
+// and ListCredentialDir for token directories, both privileged via droppriv.
+var (
+	_ security.CredentialReader    = (*CredentialCache)(nil)
+	_ security.CredentialDirLister = (*CredentialCache)(nil)
 )
 
 // CredentialCache reads credential files (the SSL server key/cert, token signing
@@ -53,6 +62,27 @@ func (c *CredentialCache) ReadCredential(path string) ([]byte, error) {
 	c.cache[path] = data
 	c.mu.Unlock()
 	return data, nil
+}
+
+// ListCredentialDir lists the entries of a credential directory as root (via
+// droppriv), so a daemon that has dropped privileges can still enumerate a
+// root-only, mode-0700 token directory such as SEC_TOKEN_SYSTEM_DIRECTORY
+// (/etc/condor/tokens.d). It satisfies cedar's security.CredentialDirLister.
+//
+// Unlike ReadCredential the listing is not cached: a token directory's contents
+// change as tokens are added, rotated, or removed, and the scan happens at most
+// once per handshake, so a stale cached listing would cost more than it saves.
+func (c *CredentialCache) ListCredentialDir(path string) ([]os.DirEntry, error) {
+	f, err := droppriv.OpenAsRoot(path)
+	if err != nil {
+		return nil, fmt.Errorf("listing credential directory %s: %w", path, err)
+	}
+	entries, err := f.ReadDir(-1)
+	_ = f.Close()
+	if err != nil {
+		return nil, fmt.Errorf("listing credential directory %s: %w", path, err)
+	}
+	return entries, nil
 }
 
 // Reload drops all cached credentials so subsequent reads re-fetch the current

--- a/credential_wiring_test.go
+++ b/credential_wiring_test.go
@@ -1,0 +1,110 @@
+package htcondor
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/bbockelm/golang-htcondor/config"
+)
+
+// TestCredentialCacheListCredentialDir checks the privileged directory lister returns the
+// directory's entries. Off-root (as under `go test`), droppriv degrades to the current
+// identity, so this exercises the read path and the DirEntry plumbing.
+func TestCredentialCacheListCredentialDir(t *testing.T) {
+	dir := t.TempDir()
+	for _, n := range []string{"tok_a", "tok_b"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := NewCredentialCache().ListCredentialDir(dir)
+	if err != nil {
+		t.Fatalf("ListCredentialDir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	if strings.Join(names, ",") != "tok_a,tok_b" {
+		t.Errorf("entries = %v, want [tok_a tok_b]", names)
+	}
+	// A missing directory is an error (surfaced, not swallowed here).
+	if _, err := NewCredentialCache().ListCredentialDir(filepath.Join(dir, "nope")); err == nil {
+		t.Error("expected error listing a missing directory")
+	}
+}
+
+func mustConfig(t *testing.T, text string) *config.Config {
+	t.Helper()
+	cfg, err := config.NewFromReader(strings.NewReader(text))
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	return cfg
+}
+
+// TestGetSecurityConfigWiresCredentials verifies every config the builders produce carries
+// the privileged reader, so outbound (client) auth can read root-owned credentials -- the
+// gap that made the master's DC_SET_READY fail on hostkey.pem.
+func TestGetSecurityConfigWiresCredentials(t *testing.T) {
+	cfg := mustConfig(t, "SEC_CLIENT_AUTHENTICATION_METHODS = SSL,TOKEN\n")
+	sc, err := GetSecurityConfig(cfg, 60000, "CLIENT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sc.Credentials == nil {
+		t.Fatal("client SecurityConfig.Credentials is nil; outbound auth cannot read root-owned credentials")
+	}
+	// The hardcoded fallback (cfg == nil path) must also carry it.
+	sc, err = GetSecurityConfigOrDefault(t.Context(), nil, 60000, "CLIENT", "peer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sc.Credentials == nil {
+		t.Error("fallback SecurityConfig.Credentials is nil")
+	}
+}
+
+// TestGetSecurityConfigDaemonTokenDir verifies the daemon-vs-tool token directory choice:
+// an explicit SEC_TOKEN_DIRECTORY always wins; a daemon with none falls back to
+// SEC_TOKEN_SYSTEM_DIRECTORY; a non-daemon does not.
+func TestGetSecurityConfigDaemonTokenDir(t *testing.T) {
+	const sysDir = "/etc/condor/tokens.d"
+	base := "SEC_CLIENT_AUTHENTICATION_METHODS = TOKEN\nSEC_TOKEN_SYSTEM_DIRECTORY = " + sysDir + "\n"
+
+	restore := runningAsDaemon
+	t.Cleanup(func() { runningAsDaemon = restore })
+
+	// Daemon, no explicit dir -> system dir.
+	runningAsDaemon = func() bool { return true }
+	sc, err := GetSecurityConfig(mustConfig(t, base), 60000, "CLIENT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sc.TokenDir != sysDir {
+		t.Errorf("daemon TokenDir = %q, want %q", sc.TokenDir, sysDir)
+	}
+
+	// Daemon, but explicit SEC_TOKEN_DIRECTORY -> explicit wins.
+	sc, err = GetSecurityConfig(mustConfig(t, base+"SEC_TOKEN_DIRECTORY = /custom/tokens.d\n"), 60000, "CLIENT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sc.TokenDir != "/custom/tokens.d" {
+		t.Errorf("explicit TokenDir = %q, want /custom/tokens.d", sc.TokenDir)
+	}
+
+	// Non-daemon, no explicit dir -> do NOT use the root-only system dir.
+	runningAsDaemon = func() bool { return false }
+	sc, err = GetSecurityConfig(mustConfig(t, base), 60000, "CLIENT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sc.TokenDir != "" {
+		t.Errorf("non-daemon TokenDir = %q, want empty (system dir is root-only)", sc.TokenDir)
+	}
+}

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -8,7 +8,7 @@ require github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7 // indirect
-	github.com/bbockelm/cedar v0.6.6 // indirect
+	github.com/bbockelm/cedar v0.6.7 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/basic/go.sum
+++ b/examples/basic/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
-github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
+github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/file_transfer_demo/go.mod
+++ b/examples/file_transfer_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/bbockelm/golang-htcondor => ../..
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7
-	github.com/bbockelm/cedar v0.6.6
+	github.com/bbockelm/cedar v0.6.7
 	github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/file_transfer_demo/go.sum
+++ b/examples/file_transfer_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
-github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
+github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/queue_demo/go.mod
+++ b/examples/queue_demo/go.mod
@@ -13,7 +13,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7 // indirect
-	github.com/bbockelm/cedar v0.6.6 // indirect
+	github.com/bbockelm/cedar v0.6.7 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/queue_demo/go.sum
+++ b/examples/queue_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
-github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
+github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/security_config/go.mod
+++ b/examples/security_config/go.mod
@@ -3,7 +3,7 @@ module github.com/bbockelm/golang-htcondor/examples/security_config
 go 1.25.7
 
 require (
-	github.com/bbockelm/cedar v0.6.6
+	github.com/bbockelm/cedar v0.6.7
 	github.com/bbockelm/golang-htcondor v0.0.0-20251113012241-ab2a8efb0537
 )
 

--- a/examples/security_config/go.sum
+++ b/examples/security_config/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
-github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
+github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/submit_demo/go.mod
+++ b/examples/submit_demo/go.mod
@@ -6,7 +6,7 @@ require github.com/bbockelm/golang-htcondor v0.0.0
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7 // indirect
-	github.com/bbockelm/cedar v0.6.6 // indirect
+	github.com/bbockelm/cedar v0.6.7 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/submit_demo/go.sum
+++ b/examples/submit_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
-github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
+github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7
-	github.com/bbockelm/cedar v0.6.6
+	github.com/bbockelm/cedar v0.6.7
 	github.com/bbockelm/gosssd v0.0.1
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/PelicanPlatform/classad/collections v0.16.7 h1:WBpuw2mTUCmpOgd3kQFkKt
 github.com/PelicanPlatform/classad/collections v0.16.7/go.mod h1:djT/JhGuLcMnVyXOsdiniPzZC6NaxQz8ZHTkffYZtNY=
 github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5UCbeKB4UQ4=
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
-github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
-github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
+github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=

--- a/localcredmon/go.mod
+++ b/localcredmon/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7 // indirect
-	github.com/bbockelm/cedar v0.6.6 // indirect
+	github.com/bbockelm/cedar v0.6.7 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect

--- a/localcredmon/go.sum
+++ b/localcredmon/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.16.7 h1:z3a/UdRK+5H6K+X3eq9O7F823ZWjzZfISKkCiSrfWgc=
 github.com/PelicanPlatform/classad v0.16.7/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
-github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
+github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/security.go
+++ b/security.go
@@ -3,6 +3,7 @@ package htcondor
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -215,6 +216,25 @@ func getRateLimitManager() *ratelimit.Manager {
 	return manager
 }
 
+// daemonCredentialCache is the process-wide privileged credential reader shared by every
+// security config this package builds, inbound and outbound. Sharing one cache means
+// cached credentials (and a single SIGHUP-driven Reload) cover all connections, and it
+// gives outbound client configs -- which are rebuilt per call, e.g. the master's
+// DC_SET_READY -- the same root-capable reader the server side already had. On a process
+// that is not privileged, droppriv.OpenAsRoot degrades to reading as the current user, so
+// wiring it unconditionally is safe for user tools too.
+var daemonCredentialCache = NewCredentialCache()
+
+// runningAsDaemon reports whether this process is an HTCondor daemon that can read
+// root-only credentials (the SSL host key, the system token directory): it is running as
+// root, or it was launched by condor_master (CONDOR_INHERIT set) and therefore started as
+// root before dropping privilege. This mirrors the "is this a daemon" test HTCondor uses
+// to choose SEC_TOKEN_SYSTEM_DIRECTORY over the per-user token directory. It is a var so
+// tests can force the non-daemon path (unit tests frequently run as root under CI).
+var runningAsDaemon = func() bool {
+	return os.Geteuid() == 0 || os.Getenv("CONDOR_INHERIT") != ""
+}
+
 // GetSecurityConfig creates a SecurityConfig from HTCondor configuration.
 // It reads security-related parameters like SEC_CLIENT_AUTHENTICATION, SEC_DEFAULT_AUTHENTICATION,
 // SEC_CLIENT_AUTHENTICATION_METHODS, etc., and maps them to the cedar SecurityConfig struct.
@@ -236,8 +256,6 @@ func getRateLimitManager() *ratelimit.Manager {
 //   - error: Any configuration error encountered
 //
 // Deficiencies (to be addressed in follow-up):
-//   - SSL certificate paths (AUTH_SSL_CLIENT_CERTFILE, etc.) not yet mapped
-//   - Token directory locations (SEC_TOKEN_DIRECTORY, etc.) not yet mapped
 //   - Authorization settings (ALLOW_READ, DENY_WRITE, etc.) are separate from SecurityConfig
 //   - Context-specific overrides beyond CLIENT not yet fully implemented
 //   - NEGOTIATION security level not yet mapped
@@ -248,6 +266,13 @@ func GetSecurityConfig(cfg *config.Config, command int, context string) (*securi
 
 	secConfig := &security.SecurityConfig{
 		Command: command,
+		// Read credentials (SSL key/cert, token files, and -- via
+		// CredentialCache.ListCredentialDir -- the token directory) through the
+		// privileged reader, so a daemon that dropped to a service account can still
+		// read root-owned 0600 credentials. Without this, an outbound auth (e.g. the
+		// master's DC_SET_READY) falls back to an unprivileged os.ReadFile and fails
+		// on /etc/grid-security/hostkey.pem and /etc/condor/tokens.d.
+		Credentials: daemonCredentialCache,
 	}
 
 	// Get authentication level
@@ -292,8 +317,17 @@ func GetSecurityConfig(cfg *config.Config, command int, context string) (*securi
 	// on the wire as "TOKEN".
 	for _, method := range secConfig.AuthMethods {
 		if method == security.AuthToken || method == security.AuthSciTokens {
-			if tokenDir, ok := cfg.Get("SEC_TOKEN_DIRECTORY"); ok {
-				secConfig.TokenDir = tokenDir
+			if tokenDir, ok := cfg.Get("SEC_TOKEN_DIRECTORY"); ok && strings.TrimSpace(tokenDir) != "" {
+				// An explicit SEC_TOKEN_DIRECTORY always wins (daemon or tool).
+				secConfig.TokenDir = strings.TrimSpace(tokenDir)
+			} else if runningAsDaemon() {
+				// A daemon with no explicit token directory reads the system token
+				// directory (SEC_TOKEN_SYSTEM_DIRECTORY, default /etc/condor/tokens.d),
+				// matching HTCondor's daemon-vs-user selection in condor_auth_passwd.
+				// The privileged reader above makes this root-only directory readable.
+				if sysDir, ok := cfg.Get("SEC_TOKEN_SYSTEM_DIRECTORY"); ok && strings.TrimSpace(sysDir) != "" {
+					secConfig.TokenDir = strings.TrimSpace(sysDir)
+				}
 			}
 			// Note: TokenFile is typically used for single-token scenarios
 			// In practice, HTCondor usually uses TokenDir with multiple tokens
@@ -373,11 +407,12 @@ func GetServerSecurityConfig(cfg *config.Config, command int, secContext string)
 		}
 	}
 
-	// Read the server's credential files (SSL key/cert, token signing keys) as
+	// The server's credential files (SSL key/cert, token signing keys) are read as
 	// root via droppriv, so they remain readable after the daemon drops to the
-	// condor account. The cache supports reload-on-SIGHUP; callers wire its
-	// Reload via daemon.OnReconfig (see CredentialReloader).
-	sc.Credentials = NewCredentialCache()
+	// condor account. GetSecurityConfig already wired the shared, reload-aware
+	// daemonCredentialCache; keep it (a SIGHUP Reload then covers server and client
+	// reads alike). Callers wire Reload via daemon.OnReconfig (see CredentialReloader).
+	sc.Credentials = daemonCredentialCache
 
 	return sc, nil
 }
@@ -668,5 +703,6 @@ func GetSecurityConfigOrDefault(ctx context.Context, cfg *config.Config, command
 		Encryption:     security.SecurityOptional,
 		Integrity:      security.SecurityOptional,
 		PeerName:       peerName,
+		Credentials:    daemonCredentialCache,
 	}, nil
 }

--- a/webapi/go.mod
+++ b/webapi/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.16.7
-	github.com/bbockelm/cedar v0.6.6
+	github.com/bbockelm/cedar v0.6.7
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/glebarez/sqlite v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/webapi/go.sum
+++ b/webapi/go.sum
@@ -48,8 +48,8 @@ github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQ
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/bbockelm/cedar v0.6.6 h1:yr8UsAxvOeni0YMjZjd3WED9fIxle8MLTPZSCX1bKsE=
-github.com/bbockelm/cedar v0.6.6/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
+github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
The wiring half of the daemon-under-`condor_master` auth fix (companion to cedar #45, now v0.6.7). Fixes both symptoms on the outbound path (e.g. the master's `DC_SET_READY`):

```
SSL: failed to read key /etc/grid-security/hostkey.pem: permission denied
… 🔐 CLIENT: Skipping TOKEN - no compatible tokens available
```

**Root cause:** the privileged credential reader (`*CredentialCache`, reads root-owned 0600 files by re-elevating via `droppriv`) was attached **only** to the server security config. Every client/outbound path (`GetSecurityConfig`, `GetSecurityConfigOrDefault`, `NewClientSecurityConfig`, and the master command builder) left `Credentials` nil, so reads fell to an unprivileged `os.ReadFile` as the dropped service user — and the root-only `/etc/condor/tokens.d` couldn't even be listed.

**Changes:**
- **Wire the reader on the client path.** One process-wide shared `daemonCredentialCache`, attached in `GetSecurityConfig`, the `OrDefault` fallback, and kept on the server path (so a single SIGHUP `Reload` covers all reads). `droppriv` degrades to the current identity when unprivileged, so it's safe for user tools.
- **Privileged directory listing.** `*CredentialCache` now implements cedar v0.6.7's `CredentialDirLister` (`ListCredentialDir` via `droppriv.OpenAsRoot`+`ReadDir`), so a root-only mode-0700 `tokens.d` can be enumerated as root.
- **Daemon token-dir selection (matches HTCondor).** Explicit `SEC_TOKEN_DIRECTORY` always wins; otherwise a daemon (root, or under `condor_master` via `CONDOR_INHERIT`) falls back to `SEC_TOKEN_SYSTEM_DIRECTORY` (default `/etc/condor/tokens.d`). A non-daemon does not reach for the root-only dir.
- Bumps `cedar` v0.6.6 → v0.6.7 across all workspace modules (`make tidy-all`).

**Tests:** `ListCredentialDir` returns entries / errors on missing dir; every builder wires `Credentials`; and the daemon-vs-tool token-dir matrix (explicit wins / daemon→system dir / non-daemon→none), with `runningAsDaemon` overridable so the non-daemon case is deterministic even when CI runs as root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
