### PR TITLE
daemon: treat a closed-listener Accept error as graceful in the drain test

### DIFF
--- a/daemon/lifecycle_test.go
+++ b/daemon/lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -38,6 +39,15 @@ func TestServeListenersServesAllAndDrains(t *testing.T) {
 			if err != nil {
 				if ctx.Err() != nil {
 					return ctx.Err()
+				}
+				// The only thing that closes this listener is the ctx.Done() goroutine
+				// above, so an Accept error reporting a closed listener means shutdown is
+				// in flight -- even if ctx.Err() isn't yet observable on this goroutine, or
+				// the close races the accept syscall so the kernel reports EBADF ("bad file
+				// descriptor") instead of Go's net.ErrClosed. Treat any closed-listener
+				// error as a graceful stop rather than a serve failure.
+				if errors.Is(err, net.ErrClosed) || errors.Is(err, syscall.EBADF) {
+					return nil
 				}
 				return err
 			}


### PR DESCRIPTION
A second, deeper race in `TestServeListenersServesAllAndDrains`, exposed under Docker-as-root CI (surfaced when #158's cedar v0.6.7 bump shifted goroutine timing):

```
ServeListeners returned accept tcp 127.0.0.1:PORT: accept4: bad file descriptor after Shutdown, want nil
```

The earlier fix removed the external dial (one race). This is a different one: on shutdown the serve loop's `Accept` observes the listener-close as a raw **`EBADF`** from the kernel rather than Go's `net.ErrClosed`, and when `ctx.Err()` isn't yet observable on the serving goroutine the raw error propagates out of `ServeListeners` as a non-nil return — failing the drain assertion.

The only thing that closes this test's listener is the `ctx.Done()` goroutine, so a closed-listener `Accept` error *always* means shutdown is in flight. Treat `net.ErrClosed` **or** `syscall.EBADF` as a graceful stop. Test-only change; `-race -count=100` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
