### PR TITLE
daemon: self-register a shared-port socket instead of standalone-binding

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -75,11 +75,12 @@ type Daemon struct {
 	shutdownCh   chan struct{} // closed by Shutdown to request a graceful stop
 	shutdownOnce sync.Once
 
-	mu               sync.Mutex
-	sharedPortName   string // shared-port "sock" id, set by Listener when adopted
-	adoptedInherited bool   // Listener returned an inherited socket (shared-port or #119), not the fallback
-	stopAlive        func()
-	onReconfig       []func(*config.Config)
+	mu                   sync.Mutex
+	sharedPortName       string // shared-port "sock" id, set by Listener when adopted or self-registered
+	sharedPortAdvertised string // advertised sinful when self-registered (master address unavailable)
+	adoptedInherited     bool   // Listener returned an inherited socket (shared-port or #119), not the fallback
+	stopAlive            func()
+	onReconfig           []func(*config.Config)
 
 	// startTime is the daemon's construction time (DaemonStartTime); lastReconfig is the last
 	// SIGHUP reconfigure (DaemonLastReconfigTime), 0 until the first. Both feed PublishAd.
@@ -229,6 +230,22 @@ func (d *Daemon) Listener(fallback func() (net.Listener, error)) (net.Listener, 
 		d.mu.Unlock()
 		return iln, nil
 	}
+	// No socket was inherited, but shared port may still be in use (e.g. started outside
+	// condor_master, or the master didn't pass a socket). Rather than a standalone bind
+	// that peers can't reach through the shared port, self-register our own named socket
+	// in the shared-port socket directory so the shared_port server routes to us.
+	if spln, sock, advertised, err := selfRegisterSharedPort(d.Config(), d.subsys, d.log); err != nil {
+		d.log.Warn(logging.DestinationGeneral,
+			"shared-port self-registration failed; falling back to standalone bind", "err", err.Error())
+	} else if spln != nil {
+		d.mu.Lock()
+		d.sharedPortName = sock
+		d.sharedPortAdvertised = advertised
+		d.mu.Unlock()
+		d.log.Info(logging.DestinationGeneral, "self-registered shared-port endpoint",
+			"sock", sock, "address", advertised)
+		return spln, nil
+	}
 	if fallback == nil {
 		return nil, fmt.Errorf("daemon: no shared-port listener inherited and no fallback provided")
 	}
@@ -270,7 +287,19 @@ func (d *Daemon) SharedPortName() string {
 // TCP_FORWARDING_HOST), supply it explicitly rather than relying on this.
 func (d *Daemon) AdvertisedSinful() (string, bool) {
 	sock := d.SharedPortName()
-	if sock == "" || d.master == nil {
+	if sock == "" {
+		return "", false
+	}
+	// When we self-registered (no inherited socket), the reachable address was derived
+	// from the shared_port server's ad file at bind time; the master address may not be
+	// available. Prefer that.
+	d.mu.Lock()
+	advertised := d.sharedPortAdvertised
+	d.mu.Unlock()
+	if advertised != "" {
+		return advertised, true
+	}
+	if d.master == nil {
 		return "", false
 	}
 	return deriveAdvertisedSinful(d.master.Address(), sock)

--- a/daemon/sharedport_selfregister.go
+++ b/daemon/sharedport_selfregister.go
@@ -1,0 +1,147 @@
+package daemon
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/bbockelm/golang-htcondor/config"
+	"github.com/bbockelm/golang-htcondor/logging"
+	"github.com/bbockelm/golang-htcondor/sharedport"
+)
+
+// selfRegisterSharedPort binds this daemon's own named socket in the shared-port socket
+// directory so the shared_port server routes forwarded connections to it. It is used when
+// the daemon was NOT handed an inherited shared-port fd (started outside condor_master, or
+// the master did not pass one) but shared port is in use -- rather than falling back to a
+// standalone TCP bind that peers cannot reach through the shared port.
+//
+// This is the client-created-socket half of HTCondor's SharedPortEndpoint: bind a UDS at
+// <DAEMON_SOCKET_DIR>/<sock>, and the shared_port server (which connects as root and tries
+// the on-disk socket directory even on Linux) forwards accepted TCP connections to it via
+// SCM_RIGHTS. The receive side is the same protocol sharedport.Listen already speaks for
+// the inherited-fd case.
+//
+// It returns the listener, the chosen "sock" id, and the advertised sinful
+// (host:port?sock=id) derived from the shared_port server's ad file. It returns
+// (nil, "", "", nil) -- telling the caller to fall back to a standalone bind -- when
+// self-registration does not apply: shared port disabled for this subsystem, no usable
+// socket directory, or the shared_port server ad (hence a routable address) is
+// unavailable. A hard bind failure is returned as an error.
+func selfRegisterSharedPort(cfg *config.Config, subsys string, logger *logging.Logger) (*sharedport.Listener, string, string, error) {
+	if cfg == nil || !sharedPortEnabled(cfg, subsys) {
+		return nil, "", "", nil
+	}
+	socketDir := daemonSocketDir(cfg)
+	if socketDir == "" {
+		logger.Warn(logging.DestinationGeneral,
+			"shared-port self-registration skipped: no DAEMON_SOCKET_DIR available; falling back to standalone bind")
+		return nil, "", "", nil
+	}
+	serverAddr, err := sharedPortServerAddress(cfg)
+	if err != nil {
+		// Without the server's public address we can't advertise a reachable sinful, and
+		// a socket nobody routes to is useless -- fall back to a standalone bind.
+		logger.Warn(logging.DestinationGeneral,
+			"shared-port self-registration skipped; falling back to standalone bind",
+			"reason", err.Error())
+		return nil, "", "", nil
+	}
+	sock := generateEndpointName(subsys)
+	advertised, ok := deriveAdvertisedSinful(serverAddr, sock)
+	if !ok {
+		logger.Warn(logging.DestinationGeneral,
+			"shared-port self-registration skipped: shared_port server address unusable; falling back to standalone bind",
+			"server_address", serverAddr)
+		return nil, "", "", nil
+	}
+
+	socketPath := filepath.Join(socketDir, sock)
+	logf := func(format string, args ...any) {
+		logger.Warn(logging.DestinationGeneral, "shared-port event", "msg", fmt.Sprintf(format, args...))
+	}
+	ln, err := sharedport.Listen(socketPath, sharedport.Options{
+		HandshakeTimeout: 10 * time.Second,
+		Logf:             logf,
+	})
+	if err != nil {
+		return nil, "", "", fmt.Errorf("bind shared-port socket %s: %w", socketPath, err)
+	}
+	return ln, sock, advertised, nil
+}
+
+// sharedPortEnabled reports whether shared port is enabled for this subsystem:
+// <SUBSYS>_USE_SHARED_PORT if set, else USE_SHARED_PORT (default true).
+func sharedPortEnabled(cfg *config.Config, subsys string) bool {
+	if subsys != "" {
+		if v, ok := cfg.Get(strings.ToUpper(subsys) + "_USE_SHARED_PORT"); ok {
+			return configTruthy(v)
+		}
+	}
+	if v, ok := cfg.Get("USE_SHARED_PORT"); ok {
+		return configTruthy(v)
+	}
+	return true
+}
+
+// daemonSocketDir resolves DAEMON_SOCKET_DIR, expanding the "auto" default to
+// $(LOCK)/daemon_sock -- matching HTCondor's GetAltDaemonSocketDir on-disk directory,
+// which the shared_port server always tries (even in the Linux abstract-socket default).
+func daemonSocketDir(cfg *config.Config) string {
+	if dir, ok := cfg.Get("DAEMON_SOCKET_DIR"); ok {
+		if d := strings.TrimSpace(dir); d != "" && d != "auto" {
+			return d
+		}
+	}
+	lock, _ := cfg.Get("LOCK")
+	if lock = strings.TrimSpace(lock); lock == "" {
+		return ""
+	}
+	return filepath.Join(lock, "daemon_sock")
+}
+
+// sharedPortServerAddress reads the shared_port server's public sinful (the MyAddress
+// attribute) from its ad file (SHARED_PORT_DAEMON_AD_FILE, default $(LOCK)/shared_port_ad),
+// which the server writes on startup. That address fronts the shared port's TCP endpoint,
+// so it is the host:port a peer dials to reach us via our sock id.
+func sharedPortServerAddress(cfg *config.Config) (string, error) {
+	adFile, _ := cfg.Get("SHARED_PORT_DAEMON_AD_FILE")
+	adFile = strings.TrimSpace(adFile)
+	if adFile == "" {
+		return "", fmt.Errorf("SHARED_PORT_DAEMON_AD_FILE not configured")
+	}
+	data, err := os.ReadFile(adFile) //nolint:gosec // G304: operator-configured ad-file path from HTCondor config
+	if err != nil {
+		return "", fmt.Errorf("reading shared_port server ad %s: %w", adFile, err)
+	}
+	ad, err := classad.ParseOld(string(data))
+	if err != nil {
+		return "", fmt.Errorf("parsing shared_port server ad %s: %w", adFile, err)
+	}
+	addr, ok := ad.EvaluateAttrString("MyAddress")
+	if !ok || strings.TrimSpace(addr) == "" {
+		return "", fmt.Errorf("shared_port server ad %s has no MyAddress", adFile)
+	}
+	return strings.TrimSpace(addr), nil
+}
+
+// generateEndpointName builds a per-daemon shared-port socket id of the form
+// <subsys>_<pid>_<rand4hex>, matching HTCondor's SharedPortEndpoint naming. The random
+// tag guards against PID reuse; the subsystem is lower-cased. The result satisfies the
+// server's socket-id charset ([A-Za-z0-9._-]) for any alphanumeric subsystem name.
+func generateEndpointName(subsys string) string {
+	name := strings.ToLower(strings.TrimSpace(subsys))
+	if name == "" {
+		name = "daemon"
+	}
+	var b [2]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand should never fail; fall back to a fixed tag rather than panic.
+		b[0], b[1] = 0, 0
+	}
+	return fmt.Sprintf("%s_%d_%02x%02x", name, os.Getpid(), b[0], b[1])
+}

--- a/daemon/sharedport_selfregister_test.go
+++ b/daemon/sharedport_selfregister_test.go
@@ -1,0 +1,212 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/bbockelm/golang-htcondor/config"
+	"github.com/bbockelm/golang-htcondor/sharedport"
+)
+
+func spConfig(t *testing.T, text string) *config.Config {
+	t.Helper()
+	cfg, err := config.NewFromReader(strings.NewReader(text))
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	return cfg
+}
+
+func TestGenerateEndpointName(t *testing.T) {
+	name := generateEndpointName("COLLECTOR")
+	// <subsys-lower>_<pid>_<4hex>, and within the server's [A-Za-z0-9._-] charset.
+	re := regexp.MustCompile(`^collector_[0-9]+_[0-9a-f]{4}$`)
+	if !re.MatchString(name) {
+		t.Errorf("generateEndpointName = %q, want match %s", name, re)
+	}
+	if !strings.HasPrefix(name, fmt.Sprintf("collector_%d_", os.Getpid())) {
+		t.Errorf("name %q missing pid segment", name)
+	}
+	// Two calls differ in the random tag.
+	first, second := generateEndpointName("X"), generateEndpointName("X")
+	if first == second {
+		t.Error("expected distinct random tags across calls")
+	}
+	// Empty subsystem falls back to a valid default.
+	if got := generateEndpointName(""); !strings.HasPrefix(got, "daemon_") {
+		t.Errorf("empty subsys = %q, want daemon_ prefix", got)
+	}
+}
+
+func TestDaemonSocketDir(t *testing.T) {
+	// "auto" (the default) -> $(LOCK)/daemon_sock.
+	cfg := spConfig(t, "LOCK = /var/lock/condor\nDAEMON_SOCKET_DIR = auto\n")
+	if got, want := daemonSocketDir(cfg), "/var/lock/condor/daemon_sock"; got != want {
+		t.Errorf("auto: got %q want %q", got, want)
+	}
+	// Explicit directory wins.
+	cfg = spConfig(t, "DAEMON_SOCKET_DIR = /run/condor/sock\n")
+	if got := daemonSocketDir(cfg); got != "/run/condor/sock" {
+		t.Errorf("explicit: got %q", got)
+	}
+}
+
+func TestSharedPortEnabled(t *testing.T) {
+	// Default is on.
+	if !sharedPortEnabled(spConfig(t, ""), "COLLECTOR") {
+		t.Error("default USE_SHARED_PORT should be enabled")
+	}
+	// Global off.
+	if sharedPortEnabled(spConfig(t, "USE_SHARED_PORT = false\n"), "COLLECTOR") {
+		t.Error("USE_SHARED_PORT=false should disable")
+	}
+	// Per-subsystem override beats the global.
+	cfg := spConfig(t, "USE_SHARED_PORT = true\nHAD_USE_SHARED_PORT = false\n")
+	if sharedPortEnabled(cfg, "HAD") {
+		t.Error("HAD_USE_SHARED_PORT=false should disable for HAD")
+	}
+	if !sharedPortEnabled(cfg, "COLLECTOR") {
+		t.Error("COLLECTOR should still follow the enabled global")
+	}
+}
+
+func TestSharedPortServerAddress(t *testing.T) {
+	dir := t.TempDir()
+	adFile := filepath.Join(dir, "shared_port_ad")
+	if err := os.WriteFile(adFile, []byte("MyType = \"shared_port\"\nMyAddress = \"<127.0.0.1:9618?addrs=127.0.0.1-9618&noUDP>\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := spConfig(t, "SHARED_PORT_DAEMON_AD_FILE = "+adFile+"\n")
+	got, err := sharedPortServerAddress(cfg)
+	if err != nil {
+		t.Fatalf("sharedPortServerAddress: %v", err)
+	}
+	if got != "<127.0.0.1:9618?addrs=127.0.0.1-9618&noUDP>" {
+		t.Errorf("MyAddress = %q", got)
+	}
+	// Missing ad file -> error.
+	cfg = spConfig(t, "SHARED_PORT_DAEMON_AD_FILE = "+filepath.Join(dir, "absent")+"\n")
+	if _, err := sharedPortServerAddress(cfg); err == nil {
+		t.Error("missing ad file should error")
+	}
+}
+
+// TestSelfRegisterSharedPort exercises the whole wiring: bind a UDS in the socket dir,
+// derive a routable advertised sinful from the server ad, and actually receive a
+// connection forwarded to that socket via the shared_port fd-pass protocol.
+func TestSelfRegisterSharedPort(t *testing.T) {
+	// A short base dir: the self-registered UDS path (<lock>/daemon_sock/<sock>) must fit
+	// in sockaddr_un's ~104-char sun_path, which the default long temp dir would blow.
+	lock := shortTempDir(t)
+	adFile := filepath.Join(lock, "shared_port_ad")
+	if err := os.WriteFile(adFile, []byte("MyAddress = \"<127.0.0.1:9618?addrs=127.0.0.1-9618&noUDP>\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := spConfig(t, "LOCK = "+lock+"\nUSE_SHARED_PORT = true\n")
+	logger := newTestDaemon(t).Logger()
+
+	ln, sock, advertised, err := selfRegisterSharedPort(cfg, "TESTD", logger)
+	if err != nil {
+		t.Fatalf("selfRegisterSharedPort: %v", err)
+	}
+	if ln == nil {
+		t.Fatal("expected a self-registered listener")
+	}
+	defer func() { _ = ln.Close() }()
+
+	if want := "127.0.0.1:9618?sock=" + sock; advertised != want {
+		t.Errorf("advertised = %q, want %q", advertised, want)
+	}
+	socketPath := filepath.Join(lock, "daemon_sock", sock)
+	if _, err := os.Stat(socketPath); err != nil {
+		t.Fatalf("socket not bound at %s: %v", socketPath, err)
+	}
+
+	// Forward a connection to our socket the way the shared_port server would, and prove
+	// Accept hands it back with the byte stream intact.
+	clientFD, passFD := mustSocketpair(t)
+	defer func() { _ = clientFD.Close() }()
+	defer func() { _ = passFD.Close() }()
+
+	udsConn, err := (&net.Dialer{}).DialContext(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial uds: %v", err)
+	}
+	defer func() { _ = udsConn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := sharedport.SendForwardedConn(ctx, udsConn.(*net.UnixConn), passFD.Fd()); err != nil {
+		t.Fatalf("SendForwardedConn: %v", err)
+	}
+
+	accepted := make(chan net.Conn, 1)
+	go func() { c, _ := ln.Accept(); accepted <- c }()
+	select {
+	case c := <-accepted:
+		if c == nil {
+			t.Fatal("Accept returned nil")
+		}
+		defer func() { _ = c.Close() }()
+		const probe = "self-register-probe"
+		if _, err := clientFD.Write([]byte(probe)); err != nil {
+			t.Fatalf("client write: %v", err)
+		}
+		buf := make([]byte, len(probe))
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+		if _, err := c.Read(buf); err != nil || string(buf) != probe {
+			t.Fatalf("forwarded read = %q, %v; want %q", buf, err, probe)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Accept did not return the forwarded connection")
+	}
+}
+
+// TestSelfRegisterSharedPortSkips covers the fall-back-to-standalone cases: shared port
+// disabled, and no shared_port server ad available.
+func TestSelfRegisterSharedPortSkips(t *testing.T) {
+	logger := newTestDaemon(t).Logger()
+
+	// USE_SHARED_PORT off -> (nil, no error): caller falls back to a standalone bind.
+	ln, _, _, err := selfRegisterSharedPort(spConfig(t, "USE_SHARED_PORT = false\n"), "TESTD", logger)
+	if err != nil || ln != nil {
+		t.Errorf("disabled: got ln=%v err=%v, want nil,nil", ln, err)
+	}
+
+	// Enabled but no server ad file -> (nil, no error): can't advertise, fall back.
+	lock := t.TempDir()
+	ln, _, _, err = selfRegisterSharedPort(spConfig(t, "LOCK = "+lock+"\nUSE_SHARED_PORT = true\n"), "TESTD", logger)
+	if err != nil || ln != nil {
+		t.Errorf("no server ad: got ln=%v err=%v, want nil,nil", ln, err)
+	}
+}
+
+// shortTempDir makes a temp dir under /tmp (not the platform default, which on macOS is a
+// long path) so a Unix-domain socket created beneath it stays within sun_path's limit.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "sp")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// mustSocketpair returns a connected pair of stream sockets as *os.File values.
+func mustSocketpair(t *testing.T) (*os.File, *os.File) {
+	t.Helper()
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	return os.NewFile(uintptr(fds[0]), "sp0"), os.NewFile(uintptr(fds[1]), "sp1")
+}


### PR DESCRIPTION
When no shared-port fd is inherited but shared port is enabled, the daemon fell back to a standalone TCP bind, which peers cannot reach through the shared port. It now self-registers: binds a named unix socket in DAEMON_SOCKET_DIR so shared_port_server routes forwarded connections to it (receive side is the existing sharedport.Listen SCM_RIGHTS path).

Daemon.Listener, between the inherited-socket checks and the standalone fallback:
- honors USE_SHARED_PORT / <SUBSYS>_USE_SHARED_PORT
- resolves DAEMON_SOCKET_DIR (auto -> $(LOCK)/daemon_sock)
- picks a sock id <subsys>_<pid>_<rand4hex>
- reads MyAddress from SHARED_PORT_DAEMON_AD_FILE to advertise <host:port?sock=id> (AdvertisedSinful works without a master)
- binds the UDS via sharedport.Listen

Falls back to the standalone bind when shared port is disabled, the socket dir is unavailable, or the server ad is missing.

Tests: sock-id format, socket-dir resolution, USE_SHARED_PORT precedence, MyAddress parsing, skip/fall-back cases, and an end-to-end fd-forward (SendForwardedConn -> Accept).
