### PR TITLE
dependabot: cover the examples/* modules in the grouped gomod update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,11 +16,17 @@ updates:
   # `replace ... => ../` self-references are local and ignored by Dependabot; it
   # manages the external dependencies (classad, cedar, fosite, ...). Minor and
   # patch bumps are grouped to cut PR noise; majors come as individual PRs.
+  #
+  # Every module must be listed: a shared dependency bumped in one module makes the
+  # others' go.mod/go.sum stale, which the CI tidy-check (make tidy-all) fails. The
+  # examples/* modules pull the shared deps transitively through the local replace, so
+  # they need updating in the same grouped PR.
   - package-ecosystem: "gomod"
     directories:
       - "/"
       - "/webapi"
       - "/localcredmon"
+      - "/examples/*"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
Adds /examples/* to the gomod update's directories.

The update listed only /, /webapi, and /localcredmon, so a shared dependency bumped in one module left the examples/* modules' go.mod/go.sum stale and failed the CI tidy-check (make tidy-all) — as seen in #161. The examples pull the shared deps transitively through their local replace, so they must be updated in the same grouped PR. Dependabot already batches across directories into one PR (via directories + groups), so this only widens coverage.
