### PR TITLE
security: wire FS auth root->condor into daemon security configs

### DIFF
--- a/credential_reader.go
+++ b/credential_reader.go
@@ -17,6 +17,18 @@ var (
 	_ security.CredentialDirLister = (*CredentialCache)(nil)
 )
 
+// condorPrivRunner adapts droppriv to cedar's security.CondorPrivRunner so cedar's FS-auth
+// client creates its marker directory as the condor service account -- droppriv switches
+// the effective identity for the mkdir, mirroring HTCondor's set_condor_priv(). Stateless.
+// On an unprivileged process droppriv runs the mkdir under the current identity, so this is
+// safe to wire onto every security config.
+type condorPrivRunner struct{}
+
+func (condorPrivRunner) RunAsCondor(fn func() error) error { return droppriv.RunAsCondor(fn) }
+
+// daemonCondorPrivRunner is the shared FS-auth marker runner wired onto security configs.
+var daemonCondorPrivRunner security.CondorPrivRunner = condorPrivRunner{}
+
 // CredentialCache reads credential files (the SSL server key/cert, token signing
 // keys) for a daemon that has dropped privileges to a service account. It reads
 // through droppriv as root — matching HTCondor's set_priv(PRIV_ROOT) — so

--- a/droppriv/operations.go
+++ b/droppriv/operations.go
@@ -187,6 +187,25 @@ func (m *Manager) ChownAsRoot(path string, uid, gid int) error {
 	})
 }
 
+// RunAsCondor runs fn with the effective identity of the condor service account -- the
+// account a daemon drops to -- restoring the prior thread credentials afterward. It is the
+// condor-identity analogue of the *AsRoot helpers: an enabled manager switches per-thread
+// via runAsUser; a disabled (unprivileged) manager runs fn under the current identity.
+// cedar's FS-auth client uses this (through a hook) to create its marker owned by condor,
+// mirroring HTCondor's set_condor_priv() so a root daemon authenticates as condor.
+func (m *Manager) RunAsCondor(fn func() error) error {
+	if !m.enabled {
+		return fn()
+	}
+	if err := runAsUser(m.defaultIdentity, fn); err != nil {
+		if errors.Is(err, ErrUnsupported) {
+			return fmt.Errorf("run as condor requested but unsupported: %w", err)
+		}
+		return err
+	}
+	return nil
+}
+
 // Package-level root functions
 
 // OpenAsRoot opens a file as root using the default manager.
@@ -211,4 +230,9 @@ func MkdirAllAsRoot(path string, perm os.FileMode) error {
 // WARNING: This bypasses all user validation. Use only when root access is required.
 func ChownAsRoot(path string, uid, gid int) error {
 	return DefaultManager().ChownAsRoot(path, uid, gid)
+}
+
+// RunAsCondor runs fn as the condor service account using the default manager.
+func RunAsCondor(fn func() error) error {
+	return DefaultManager().RunAsCondor(fn)
 }

--- a/droppriv/runascondor_test.go
+++ b/droppriv/runascondor_test.go
@@ -1,0 +1,23 @@
+package droppriv
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestManagerRunAsCondorDisabled: a disabled manager (an unprivileged process) runs fn
+// under the current identity and propagates its error, without attempting a switch.
+func TestManagerRunAsCondorDisabled(t *testing.T) {
+	ran := false
+	if err := (&Manager{}).RunAsCondor(func() error { ran = true; return nil }); err != nil {
+		t.Fatalf("RunAsCondor: %v", err)
+	}
+	if !ran {
+		t.Error("fn should run when the manager is disabled")
+	}
+
+	boom := errors.New("boom")
+	if err := (&Manager{}).RunAsCondor(func() error { return boom }); !errors.Is(err, boom) {
+		t.Errorf("RunAsCondor error = %v, want boom", err)
+	}
+}

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -8,7 +8,7 @@ require github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 
 require (
 	github.com/PelicanPlatform/classad v0.18.0 // indirect
-	github.com/bbockelm/cedar v0.6.7 // indirect
+	github.com/bbockelm/cedar v0.6.8 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/basic/go.sum
+++ b/examples/basic/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.18.0 h1:wUzVG0fLxQlMiPeZ3zMlhl1ifd3VpgDuQdqSblNjwEA=
 github.com/PelicanPlatform/classad v0.18.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
-github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.8 h1:Poztcrgb0h3ZUO7T0F1lySez5WCkzjYNCPOZdkUpAoA=
+github.com/bbockelm/cedar v0.6.8/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/file_transfer_demo/go.mod
+++ b/examples/file_transfer_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/bbockelm/golang-htcondor => ../..
 
 require (
 	github.com/PelicanPlatform/classad v0.18.0
-	github.com/bbockelm/cedar v0.6.7
+	github.com/bbockelm/cedar v0.6.8
 	github.com/bbockelm/golang-htcondor v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/file_transfer_demo/go.sum
+++ b/examples/file_transfer_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.18.0 h1:wUzVG0fLxQlMiPeZ3zMlhl1ifd3VpgDuQdqSblNjwEA=
 github.com/PelicanPlatform/classad v0.18.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
-github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.8 h1:Poztcrgb0h3ZUO7T0F1lySez5WCkzjYNCPOZdkUpAoA=
+github.com/bbockelm/cedar v0.6.8/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/queue_demo/go.mod
+++ b/examples/queue_demo/go.mod
@@ -13,7 +13,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad v0.18.0 // indirect
-	github.com/bbockelm/cedar v0.6.7 // indirect
+	github.com/bbockelm/cedar v0.6.8 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/queue_demo/go.sum
+++ b/examples/queue_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.18.0 h1:wUzVG0fLxQlMiPeZ3zMlhl1ifd3VpgDuQdqSblNjwEA=
 github.com/PelicanPlatform/classad v0.18.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
-github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.8 h1:Poztcrgb0h3ZUO7T0F1lySez5WCkzjYNCPOZdkUpAoA=
+github.com/bbockelm/cedar v0.6.8/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/security_config/go.mod
+++ b/examples/security_config/go.mod
@@ -3,7 +3,7 @@ module github.com/bbockelm/golang-htcondor/examples/security_config
 go 1.25.7
 
 require (
-	github.com/bbockelm/cedar v0.6.7
+	github.com/bbockelm/cedar v0.6.8
 	github.com/bbockelm/golang-htcondor v0.0.0-20251113012241-ab2a8efb0537
 )
 

--- a/examples/security_config/go.sum
+++ b/examples/security_config/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.18.0 h1:wUzVG0fLxQlMiPeZ3zMlhl1ifd3VpgDuQdqSblNjwEA=
 github.com/PelicanPlatform/classad v0.18.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
-github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.8 h1:Poztcrgb0h3ZUO7T0F1lySez5WCkzjYNCPOZdkUpAoA=
+github.com/bbockelm/cedar v0.6.8/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/submit_demo/go.mod
+++ b/examples/submit_demo/go.mod
@@ -6,7 +6,7 @@ require github.com/bbockelm/golang-htcondor v0.0.0
 
 require (
 	github.com/PelicanPlatform/classad v0.18.0 // indirect
-	github.com/bbockelm/cedar v0.6.7 // indirect
+	github.com/bbockelm/cedar v0.6.8 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/examples/submit_demo/go.sum
+++ b/examples/submit_demo/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.18.0 h1:wUzVG0fLxQlMiPeZ3zMlhl1ifd3VpgDuQdqSblNjwEA=
 github.com/PelicanPlatform/classad v0.18.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
-github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.8 h1:Poztcrgb0h3ZUO7T0F1lySez5WCkzjYNCPOZdkUpAoA=
+github.com/bbockelm/cedar v0.6.8/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/fs_condor_test.go
+++ b/fs_condor_test.go
@@ -1,0 +1,39 @@
+package htcondor
+
+import "testing"
+
+func TestCondorUsername(t *testing.T) {
+	if got := condorUsername(mustConfig(t, "")); got != "condor" {
+		t.Errorf("default = %q, want condor", got)
+	}
+	if got := condorUsername(mustConfig(t, "CONDOR_USER = svc\n")); got != "svc" {
+		t.Errorf("override = %q, want svc", got)
+	}
+}
+
+func TestFSRootToCondor(t *testing.T) {
+	if fsRootToCondor(mustConfig(t, "")) != nil {
+		t.Error("unset should be nil (leave cedar's default)")
+	}
+	if p := fsRootToCondor(mustConfig(t, "FS_ROOT_TO_CONDOR = false\n")); p == nil || *p {
+		t.Errorf("false should be &false, got %v", p)
+	}
+	if p := fsRootToCondor(mustConfig(t, "FS_ROOT_TO_CONDOR = true\n")); p == nil || !*p {
+		t.Errorf("true should be &true, got %v", p)
+	}
+}
+
+// TestGetSecurityConfigWiresFSCondor verifies the FS-auth root->condor fields are set on
+// the security config the builder produces.
+func TestGetSecurityConfigWiresFSCondor(t *testing.T) {
+	sc, err := GetSecurityConfig(mustConfig(t, "SEC_CLIENT_AUTHENTICATION_METHODS = FS\nCONDOR_USER = svc\n"), 60000, "CLIENT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sc.CondorUsername != "svc" {
+		t.Errorf("CondorUsername = %q, want svc", sc.CondorUsername)
+	}
+	if sc.CondorPrivRunner == nil {
+		t.Error("CondorPrivRunner should be wired onto the config")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.18.0
-	github.com/bbockelm/cedar v0.6.7
+	github.com/bbockelm/cedar v0.6.8
 	github.com/bbockelm/gosssd v0.0.1
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/PelicanPlatform/classad/collections v0.18.0 h1:lmPnjBjOa676AJoeNqO9CT
 github.com/PelicanPlatform/classad/collections v0.18.0/go.mod h1:djT/JhGuLcMnVyXOsdiniPzZC6NaxQz8ZHTkffYZtNY=
 github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5UCbeKB4UQ4=
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
-github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
-github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.8 h1:Poztcrgb0h3ZUO7T0F1lySez5WCkzjYNCPOZdkUpAoA=
+github.com/bbockelm/cedar v0.6.8/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=

--- a/localcredmon/go.mod
+++ b/localcredmon/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/PelicanPlatform/classad v0.18.0 // indirect
-	github.com/bbockelm/cedar v0.6.7 // indirect
+	github.com/bbockelm/cedar v0.6.8 // indirect
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect

--- a/localcredmon/go.sum
+++ b/localcredmon/go.sum
@@ -1,7 +1,7 @@
 github.com/PelicanPlatform/classad v0.18.0 h1:wUzVG0fLxQlMiPeZ3zMlhl1ifd3VpgDuQdqSblNjwEA=
 github.com/PelicanPlatform/classad v0.18.0/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
-github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
-github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.8 h1:Poztcrgb0h3ZUO7T0F1lySez5WCkzjYNCPOZdkUpAoA=
+github.com/bbockelm/cedar v0.6.8/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/security.go
+++ b/security.go
@@ -235,6 +235,41 @@ var runningAsDaemon = func() bool {
 	return os.Geteuid() == 0 || os.Getenv("CONDOR_INHERIT") != ""
 }
 
+// condorUsername returns the condor service account name (CONDOR_USER, default "condor"),
+// used by FS auth to map a root-owned marker to the condor identity.
+func condorUsername(cfg *config.Config) string {
+	if cfg != nil {
+		if v, ok := cfg.Get("CONDOR_USER"); ok {
+			if s := strings.TrimSpace(v); s != "" {
+				return s
+			}
+		}
+	}
+	return "condor"
+}
+
+// fsRootToCondor reads FS_ROOT_TO_CONDOR as a tri-state: nil (unset) leaves cedar's
+// default (enabled, matching HTCondor); an explicit value overrides it.
+func fsRootToCondor(cfg *config.Config) *bool {
+	if cfg == nil {
+		return nil
+	}
+	v, ok := cfg.Get("FS_ROOT_TO_CONDOR")
+	if !ok {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "":
+		return nil
+	case "true", "t", "1", "yes", "y", "on":
+		b := true
+		return &b
+	default:
+		b := false
+		return &b
+	}
+}
+
 // GetSecurityConfig creates a SecurityConfig from HTCondor configuration.
 // It reads security-related parameters like SEC_CLIENT_AUTHENTICATION, SEC_DEFAULT_AUTHENTICATION,
 // SEC_CLIENT_AUTHENTICATION_METHODS, etc., and maps them to the cedar SecurityConfig struct.
@@ -273,6 +308,13 @@ func GetSecurityConfig(cfg *config.Config, command int, context string) (*securi
 		// master's DC_SET_READY) falls back to an unprivileged os.ReadFile and fails
 		// on /etc/grid-security/hostkey.pem and /etc/condor/tokens.d.
 		Credentials: daemonCredentialCache,
+		// FS auth: create the marker as condor (client, via droppriv) and map a
+		// root-owned marker to condor (server), so a tool or daemon run as root
+		// authenticates as condor rather than root -- mirroring C++ set_condor_priv()
+		// and FS_ROOT_TO_CONDOR. On an unprivileged process the runner is a no-op.
+		CondorUsername:   condorUsername(cfg),
+		CondorPrivRunner: daemonCondorPrivRunner,
+		FSRootToCondor:   fsRootToCondor(cfg),
 	}
 
 	// Get authentication level

--- a/webapi/go.mod
+++ b/webapi/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/PelicanPlatform/classad v0.18.0
-	github.com/bbockelm/cedar v0.6.7
+	github.com/bbockelm/cedar v0.6.8
 	github.com/bbockelm/gosssd v0.0.1 // indirect
 	github.com/glebarez/sqlite v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/webapi/go.sum
+++ b/webapi/go.sum
@@ -48,8 +48,8 @@ github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQ
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/bbockelm/cedar v0.6.7 h1:i3QkzCbBsj19Qe/sCTM9ulVWY6vMNFEJl9Alg403Q1Q=
-github.com/bbockelm/cedar v0.6.7/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
+github.com/bbockelm/cedar v0.6.8 h1:Poztcrgb0h3ZUO7T0F1lySez5WCkzjYNCPOZdkUpAoA=
+github.com/bbockelm/cedar v0.6.8/go.mod h1:C4u6CKJoweg3LZniOi7Yh8avQv1KZjHs9k1vTGa1+2w=
 github.com/bbockelm/gosssd v0.0.1 h1:p9wJYl+GDn29W1it2ZE2RekriwUNs/1U16aUNNro5SM=
 github.com/bbockelm/gosssd v0.0.1/go.mod h1:Hz8jIcIkQnFmA/ekP2ZWpnPqmyIxftPPFsi+Y3wqRL0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
Activates cedar v0.6.8's FS root->condor behavior so a daemon or tool run as root authenticates as `condor`, not `root` (matching C++ condor_auth_fs).

- **droppriv**: add `RunAsCondor` (manager method + package func), the condor-identity analogue of the `*AsRoot` helpers — an enabled manager switches per-thread via `runAsUser`; a disabled one runs fn under the current identity.
- **GetSecurityConfig**: set `CondorUsername` (CONDOR_USER, default "condor"), `FSRootToCondor` (from the knob; unset leaves cedar's default of on), and a droppriv-backed `CondorPrivRunner` so cedar's FS-auth client creates its marker owned by condor. On an unprivileged process the runner is a no-op, so non-root behavior is unchanged.

Bumps cedar v0.6.7 -> v0.6.8 across all modules (make tidy-all).

Tests: `condorUsername` default/override, `fsRootToCondor` tri-state, the config wiring, and `RunAsCondor` on a disabled manager.
