### PR TITLE
httpserver: fix owner-scope injection in chat tools + scope bulk endpoints

### DIFF
--- a/webapi/httpserver/handlers.go
+++ b/webapi/httpserver/handlers.go
@@ -897,6 +897,30 @@ func (s *Handler) handleEditJob(w http.ResponseWriter, r *http.Request, jobID st
 }
 
 // handleBulkDeleteJobs handles DELETE /api/v1/jobs with constraint-based bulk removal
+// bulkOwnerScope owner-scopes a destructive bulk operation's constraint so a
+// caller can only remove/edit their OWN jobs, unless they are a Web UI admin
+// (who may operate cross-user). This mirrors the read path's ownedByMe logic
+// (a Web UI session that is not an admin is confined to its own jobs), and uses
+// the same injection-safe wrapper as the chat tools (scopeToOwner: the untrusted
+// constraint is parsed and re-serialized before being AND-ed with the owner
+// clause, and rejected if it will not parse). The schedd ACL is still the
+// ultimate backstop; this just removes the footgun of a bulk delete/edit that
+// silently trusts an arbitrary caller-supplied constraint.
+//
+// Non-session (API-token) callers are left to the schedd ACL exactly as the read
+// path leaves them, so existing service integrations are unaffected.
+func (s *Handler) bulkOwnerScope(ctx context.Context, r *http.Request, raw string) (string, error) {
+	_, hasSession := s.getSessionFromRequest(r)
+	if !hasSession || s.isWebUIAdmin(r) {
+		return raw, nil
+	}
+	owner := htcondor.GetAuthenticatedUserFromContext(ctx)
+	if owner == "" {
+		return "", fmt.Errorf("cannot determine the authenticated user for owner scoping")
+	}
+	return scopeToOwner(owner, raw)
+}
+
 func (s *Handler) handleBulkDeleteJobs(w http.ResponseWriter, r *http.Request) {
 	// Create authenticated context
 	ctx, needsRedirect, err := s.requireAuthentication(r)
@@ -929,8 +953,16 @@ func (s *Handler) handleBulkDeleteJobs(w http.ResponseWriter, r *http.Request) {
 		req.Reason = "Removed via HTTP API bulk operation"
 	}
 
+	// Owner-scope the constraint (non-admin Web UI callers can only remove their
+	// own jobs); rejects a constraint that will not parse.
+	constraint, err := s.bulkOwnerScope(ctx, r, req.Constraint)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
 	// Remove jobs by constraint
-	results, err := s.getSchedd().RemoveJobs(ctx, req.Constraint, req.Reason)
+	results, err := s.getSchedd().RemoveJobs(ctx, constraint, req.Reason)
 	if err != nil {
 		// Check if it's an authentication error
 		if isAuthenticationError(err) {
@@ -1022,8 +1054,16 @@ func (s *Handler) handleBulkEditJobs(w http.ResponseWriter, r *http.Request) {
 		opts.Force = req.Options.Force
 	}
 
+	// Owner-scope the constraint (non-admin Web UI callers can only edit their
+	// own jobs); rejects a constraint that will not parse.
+	constraint, err := s.bulkOwnerScope(ctx, r, req.Constraint)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
 	// Edit jobs matching constraint
-	count, err := s.getSchedd().EditJobs(ctx, req.Constraint, attributes, opts)
+	count, err := s.getSchedd().EditJobs(ctx, constraint, attributes, opts)
 	if err != nil {
 		// Check if it's a validation error (immutable/protected attribute)
 		if strings.Contains(err.Error(), "immutable") || strings.Contains(err.Error(), "protected") {

--- a/webapi/httpserver/handlers_bulk_scope_test.go
+++ b/webapi/httpserver/handlers_bulk_scope_test.go
@@ -1,0 +1,77 @@
+package httpserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	htcondor "github.com/bbockelm/golang-htcondor"
+)
+
+// TestBulkOwnerScope covers the destructive bulk-endpoint owner scoping: a Web UI
+// session that is not an admin is confined to its own jobs (and an injection
+// constraint is rejected), while an admin session and a non-session API-token
+// caller pass through unchanged (schedd ACL is their boundary).
+func TestBulkOwnerScope(t *testing.T) {
+	server, err := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		ScheddName:   "test",
+		ScheddAddr:   "127.0.0.1:9618",
+		SessionTTL:   time.Hour,
+		OAuth2DBPath: t.TempDir() + "/t.db",
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ctx := htcondor.WithAuthenticatedUser(context.Background(), "alice")
+
+	reqWithSession := func(user string, groups ...[]string) *http.Request {
+		sid, _, err := server.sessionStore.Create(user, groups...)
+		if err != nil {
+			t.Fatalf("session create: %v", err)
+		}
+		r := httptest.NewRequestWithContext(context.Background(), "POST", "/", nil)
+		r.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid}) //nolint:gosec
+		return r
+	}
+
+	t.Run("no session passes through (API token -> schedd ACL)", func(t *testing.T) {
+		r := httptest.NewRequestWithContext(context.Background(), "POST", "/", nil)
+		got, err := server.bulkOwnerScope(ctx, r, `JobStatus == 5`)
+		if err != nil || got != `JobStatus == 5` {
+			t.Errorf("got (%q, %v), want passthrough", got, err)
+		}
+	})
+
+	t.Run("non-admin session is owner-scoped", func(t *testing.T) {
+		r := reqWithSession("alice")
+		scoped, err := server.bulkOwnerScope(ctx, r, `JobStatus == 5`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if scopeAdmits(t, scoped, "bob") {
+			t.Errorf("BYPASS: non-admin scope admits bob: %q", scoped)
+		}
+		if !scopeAdmits(t, scoped, "alice") {
+			t.Errorf("owner wrongly excluded: %q", scoped)
+		}
+	})
+
+	t.Run("non-admin session rejects an injection constraint", func(t *testing.T) {
+		r := reqWithSession("alice")
+		if _, err := server.bulkOwnerScope(ctx, r, `true) || (true`); err == nil {
+			t.Error("injection constraint must be rejected for a non-admin session")
+		}
+	})
+
+	t.Run("admin session bypasses scoping", func(t *testing.T) {
+		server.webuiAdminGroup = "condor-admins"
+		r := reqWithSession("root", []string{"condor-admins"})
+		got, err := server.bulkOwnerScope(ctx, r, `JobStatus == 5`)
+		if err != nil || got != `JobStatus == 5` {
+			t.Errorf("admin: got (%q, %v), want passthrough", got, err)
+		}
+	})
+}

--- a/webapi/httpserver/handlers_chat_job_detail_tools.go
+++ b/webapi/httpserver/handlers_chat_job_detail_tools.go
@@ -466,7 +466,10 @@ func (s *Handler) toolEditJobsByConstraint() chat.Tool {
 				}
 			}
 
-			scoped := scopeToOwner(actor, args.Constraint)
+			scoped, err := scopeToOwner(actor, args.Constraint)
+			if err != nil {
+				return "", err
+			}
 			schedd := s.getSchedd()
 			count, err := schedd.EditJobs(ctx, scoped, args.Attributes,
 				&htcondor.EditJobOptions{})

--- a/webapi/httpserver/handlers_chat_tools.go
+++ b/webapi/httpserver/handlers_chat_tools.go
@@ -452,7 +452,10 @@ func (s *Handler) toolQueryJobs() chat.Tool {
 			if limit > 100 {
 				limit = 100
 			}
-			constraint := scopeToOwner(actor, args.Constraint)
+			constraint, err := scopeToOwner(actor, args.Constraint)
+			if err != nil {
+				return "", err
+			}
 
 			schedd := s.getSchedd()
 			ads, _, err := schedd.QueryWithOptions(ctx, constraint, &htcondor.QueryOptions{
@@ -568,7 +571,10 @@ func (s *Handler) toolQueryJobsArchive() chat.Tool {
 			// pagination cursor. Same predicate the SPA uses on the
 			// archive page — kept consistent so the LLM and the user
 			// scrolling the table see the same record set.
-			constraint := scopeToOwner(actor, args.Constraint)
+			constraint, err := scopeToOwner(actor, args.Constraint)
+			if err != nil {
+				return "", err
+			}
 			if args.BeforeCluster > 0 {
 				cursorPredicate := fmt.Sprintf(
 					"(ClusterId < %d || (ClusterId == %d && ProcId < %d))",
@@ -767,7 +773,10 @@ func (s *Handler) toolRemoveJobs() chat.Tool {
 				return "", fmt.Errorf("either cluster_id or constraint is required (refusing to remove every job)")
 			}
 
-			constraint := scopeToOwner(actor, llmConstraint)
+			constraint, err := scopeToOwner(actor, llmConstraint)
+			if err != nil {
+				return "", err
+			}
 			schedd := s.getSchedd()
 
 			// Pre-count: query the matching set with a projection
@@ -984,19 +993,55 @@ func toolHighlightJob() chat.Tool {
 // scopeToOwner is the centerpiece of the chat layer's owner-scoping
 // guarantee. Whatever ClassAd expression the LLM passes, we wrap it
 // so the result evaluates to (Owner == "<actor>") AND (whatever the
-// LLM asked for). The LLM cannot remove or escape the leading clause
-// — the AND-wrapper is unconditional.
+// LLM asked for), and the LLM cannot escape the leading clause.
+//
+// The AND-wrapper alone is NOT sufficient: `&&` binds tighter than
+// `||`, so a raw `(owner) && (llm)` is defeated by an `llm` that
+// carries an unbalanced `)` and a top-level `||` (e.g. `true) || (true`
+// → `(owner) && (true) || (true)` = every job). The constraint is
+// therefore parsed and re-serialized (classadBalanced) before it is
+// wrapped: the round-tripped form is always balanced, so the wrapper
+// confines it — and an input that will not parse is rejected outright
+// rather than silently widened.
 //
 // Empty-string actor is rejected at the handler layer, not here, so
 // this function never produces a `Owner == ""` constraint that
 // matches everything.
-func scopeToOwner(actor, llmConstraint string) string {
+func scopeToOwner(actor, llmConstraint string) (string, error) {
 	owner := fmt.Sprintf("Owner == %s", classadStringLit(actor))
 	c := strings.TrimSpace(llmConstraint)
 	if c == "" {
-		return owner
+		return owner, nil
 	}
-	return fmt.Sprintf("(%s) && (%s)", owner, c)
+	// The AND-wrapper only confines the LLM constraint if the constraint cannot
+	// escape it. Raw concatenation does NOT: because ClassAd `||` binds looser
+	// than `&&` and the constraint may carry unbalanced parentheses, an input like
+	// `true) || (true` yields `(Owner==actor) && (true) || (true)` — which parses
+	// as `... || true` and matches EVERY job, defeating the scope (and, via
+	// remove_jobs / edit_jobs_by_constraint, letting a jailbroken LLM touch other
+	// users' jobs). Re-serialize the constraint through the ClassAd parser: the
+	// round-tripped form is always balanced, so the wrapper confines it. Reject
+	// anything that will not parse rather than silently widening the scope — for a
+	// destructive tool, failing the call is far safer than falling back to
+	// "every job the user owns".
+	safe, err := classadBalanced(c)
+	if err != nil {
+		return "", fmt.Errorf("constraint is not a valid ClassAd expression: %w", err)
+	}
+	return fmt.Sprintf("(%s) && (%s)", owner, safe), nil
+}
+
+// classadBalanced parses an untrusted ClassAd boolean expression and returns its
+// re-serialized (balanced) form, safe to splice as one operand of a larger
+// expression. It errors on anything that does not parse as a single complete
+// expression — which is exactly how an owner-scope-bypass attempt (unbalanced
+// parentheses to escape an enclosing `&&`) is rejected.
+func classadBalanced(constraint string) (string, error) {
+	expr, err := classad.ParseExpr(constraint)
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
 }
 
 // classadStringLit quotes a value as a ClassAd string literal,

--- a/webapi/httpserver/handlers_chat_tools_test.go
+++ b/webapi/httpserver/handlers_chat_tools_test.go
@@ -3,100 +3,112 @@ package httpserver
 import (
 	"strings"
 	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
 )
 
-// TestScopeToOwner pins the contract that whatever the LLM passes
-// as a constraint, the chat layer's owner-scoping wraps it so the
-// server-issued query ALWAYS evaluates Owner == "<actor>" first.
-// This is the primary defense against an LLM being prompted into
-// "show me all jobs" — the LLM cannot escape the wrapper.
-func TestScopeToOwner(t *testing.T) {
-	cases := []struct {
-		name           string
-		actor          string
-		llmConstraint  string
-		mustContain    []string
-		mustNotContain []string
-	}{
-		{
-			name:          "empty constraint produces owner-only filter",
-			actor:         "alice",
-			llmConstraint: "",
-			mustContain:   []string{`Owner == "alice"`},
-		},
-		{
-			name:          "non-empty constraint AND-wrapped with owner",
-			actor:         "alice",
-			llmConstraint: "JobStatus == 5",
-			mustContain:   []string{`Owner == "alice"`, `JobStatus == 5`, "&&"},
-		},
-		{
-			name:          "LLM-supplied owner-override is neutralized by AND-wrap",
-			actor:         "alice",
-			llmConstraint: `Owner == "bob" || true`,
-			// The AND-wrapper means the result is
-			//   (Owner == "alice") && (Owner == "bob" || true)
-			// → still requires Owner == "alice", so the LLM's
-			// attempt to widen the scope can't take effect.
-			mustContain: []string{`Owner == "alice"`, `&&`},
-		},
-		{
-			name:          "double-quote in actor is escaped",
-			actor:         `name"with"quote`,
-			llmConstraint: "",
-			mustContain:   []string{`Owner == "name\"with\"quote"`},
-		},
-		{
-			name:          "backslash in actor is escaped",
-			actor:         `back\slash`,
-			llmConstraint: "",
-			mustContain:   []string{`Owner == "back\\slash"`},
-		},
+// scopeAdmits parses a scoped constraint and reports whether it matches a job
+// owned by owner. A correctly owner-scoped constraint must admit ONLY the actor's
+// own jobs, no matter what the LLM passed — this evaluates that against the real
+// ClassAd engine rather than a lexical string check (a lexical check cannot catch
+// the `||`/unbalanced-paren bypass and is what let it slip in originally).
+func scopeAdmits(t *testing.T, scoped, owner string) bool {
+	t.Helper()
+	expr, err := classad.ParseExpr(scoped)
+	if err != nil {
+		t.Fatalf("scoped constraint did not parse: %q: %v", scoped, err)
+	}
+	ad := classad.New()
+	ad.InsertAttrString("Owner", owner)
+	ad.InsertAttr("JobStatus", 5)
+	b, _ := expr.Eval(ad).BoolValue()
+	return b
+}
+
+// TestScopeToOwnerConfinesToActor is the security contract: whatever the LLM
+// passes, the scoped constraint may match ONLY the actor's own jobs. Evaluated
+// against the real classad engine for a battery of benign and hostile inputs.
+func TestScopeToOwnerConfinesToActor(t *testing.T) {
+	const actor = "alice"
+	cases := []string{
+		"",                      // owner-only
+		"JobStatus == 5",        // benign filter
+		`Owner == "bob" || true`, // tautology that tries to widen
+		"JobStatus == 5 || 1 == 1",
+	}
+	for _, c := range cases {
+		scoped, err := scopeToOwner(actor, c)
+		if err != nil {
+			t.Fatalf("scopeToOwner(%q, %q) unexpected error: %v", actor, c, err)
+		}
+		if scopeAdmits(t, scoped, "bob") {
+			t.Errorf("BYPASS: constraint %q admits bob's jobs via %q", c, scoped)
+		}
+		if scopeAdmits(t, scoped, "carol") {
+			t.Errorf("BYPASS: constraint %q admits carol's jobs via %q", c, scoped)
+		}
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := scopeToOwner(tc.actor, tc.llmConstraint)
-			for _, want := range tc.mustContain {
-				if !strings.Contains(got, want) {
-					t.Errorf("scopeToOwner(%q, %q) = %q, missing %q",
-						tc.actor, tc.llmConstraint, got, want)
-				}
-			}
-			for _, banned := range tc.mustNotContain {
-				if strings.Contains(got, banned) {
-					t.Errorf("scopeToOwner(%q, %q) = %q, must not contain %q",
-						tc.actor, tc.llmConstraint, got, banned)
-				}
-			}
-		})
+	// Benign self-scoped filters must still see the actor's own jobs.
+	for _, c := range []string{"", "JobStatus == 5"} {
+		scoped, err := scopeToOwner(actor, c)
+		if err != nil {
+			t.Fatalf("scopeToOwner(%q, %q): %v", actor, c, err)
+		}
+		if !scopeAdmits(t, scoped, "alice") {
+			t.Errorf("constraint %q wrongly excludes the owner: %q", c, scoped)
+		}
 	}
 }
 
-// TestScopeToOwnerWrapperIsAtomic is the high-level invariant: no
-// matter what the LLM passes, the resulting constraint includes
-// `Owner == "<actor>"` as an unconditional clause that ANDs with
-// everything else. We can't prove this without a real classad
-// evaluator, so the test asserts the structural property — the
-// whole LLM constraint is wrapped in parens, which means an OR at
-// the top level of the LLM-supplied string can never short-circuit
-// the leading owner clause.
-func TestScopeToOwnerWrapperIsAtomic(t *testing.T) {
-	// Pathological LLM output: tries to inject a `||` so the
-	// resulting expression is "Owner==alice || everything-else".
-	//
-	// scopeToOwner wraps the LLM clause in parens, so the resulting
-	// string is "(Owner == \"alice\") && (... || ...)" — the OR
-	// is contained inside the right-hand operand of the AND and
-	// can't override the owner clause.
-	got := scopeToOwner("alice", `1 == 1 || Owner == "bob"`)
-
-	// Lexical check: the owner clause is followed by `) && (` or
-	// equivalent — confirming the LLM's text is parenthesized.
-	if !strings.HasPrefix(got, `(Owner == "alice") && (`) {
-		t.Errorf("scopeToOwner output missing the protective wrap: %q", got)
+// TestScopeToOwnerRejectsInjection: a constraint crafted to escape the AND via
+// unbalanced parentheses must be REJECTED (not silently widened), so a
+// destructive tool (remove_jobs / edit_jobs_by_constraint) fails the call rather
+// than acting on every job.
+func TestScopeToOwnerRejectsInjection(t *testing.T) {
+	injections := []string{
+		`true) || (true`,
+		`Owner == "bob") || (true`,
+		`1) || (JobStatus =?= JobStatus`,
+		`JobStatus == 5) || (1 == 1`,
 	}
-	if !strings.HasSuffix(got, `)`) {
-		t.Errorf("scopeToOwner output not closed by paren: %q", got)
+	for _, c := range injections {
+		if _, err := scopeToOwner("alice", c); err == nil {
+			t.Errorf("scopeToOwner(alice, %q) should have errored (injection), but succeeded", c)
+		}
+	}
+}
+
+// TestScopeToOwnerEscaping keeps the actor-quoting contract: quotes and
+// backslashes in the (server-derived) actor are escaped into the literal.
+func TestScopeToOwnerEscaping(t *testing.T) {
+	cases := []struct {
+		actor string
+		want  string
+	}{
+		{`name"with"quote`, `Owner == "name\"with\"quote"`},
+		{`back\slash`, `Owner == "back\\slash"`},
+	}
+	for _, tc := range cases {
+		got, err := scopeToOwner(tc.actor, "")
+		if err != nil {
+			t.Fatalf("scopeToOwner(%q, \"\"): %v", tc.actor, err)
+		}
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("scopeToOwner(%q, \"\") = %q, missing %q", tc.actor, got, tc.want)
+		}
+	}
+}
+
+func TestClassadBalanced(t *testing.T) {
+	for _, bad := range []string{`true) || (true`, `Owner == "bob") || (true`, `) || (`} {
+		if _, err := classadBalanced(bad); err == nil {
+			t.Errorf("classadBalanced(%q) should have errored", bad)
+		}
+	}
+	for _, good := range []string{`true`, `JobStatus == 5`, `Owner == "bob" || true`} {
+		if _, err := classadBalanced(good); err != nil {
+			t.Errorf("classadBalanced(%q) errored: %v", good, err)
+		}
 	}
 }


### PR DESCRIPTION
## Fix owner-scope ClassAd injection in the chat tools (live on `main`)

An adversarial injection audit found that the chat layer's `scopeToOwner` builds
`(Owner==actor) && (constraint)` by **raw string concatenation** with the
LLM-supplied constraint spliced in unparsed. Because ClassAd `||` binds looser
than `&&` and the constraint can carry unbalanced parens, a crafted value escapes
the AND:

```
constraint = true) || (true
  => (Owner == "alice") && (true) || (true)
  => ((Owner=="alice") && true) || true   =>  matches EVERY job
```

The function's own doc comment and unit test claimed the paren-wrap made this
impossible — but the test only fed a **balanced-paren** input, so the bypass was
untested and live. (This is the httpserver twin of the mcpserver bug already fixed
on the `mcp-db-tools` branch.)

### Blast radius — one helper backs four tools, two destructive
| Tool | Op | Guard | Severity |
|------|-----|-------|----------|
| `edit_jobs_by_constraint` | EDIT arbitrary attrs | none | **Critical** |
| `remove_jobs` | REMOVE | pre-count cap 1000 (queried with the *bypassed* constraint) | High |
| `query_jobs` / `query_jobs_archive` | READ | — | Med (cross-user leak) |

A prompt-injected / jailbroken LLM could edit, remove, or read **other users'
jobs** (modulo the schedd ACL — which the code comments note is often a single
privileged service identity).

### Fix
`classadBalanced()` parses the untrusted constraint and re-serializes the balanced
form (`ParseExpr(c).String()`) before it is AND-ed with the owner clause — the
round-tripped form can't escape the wrapper. `scopeToOwner` now returns an
**error and rejects** anything that won't parse, rather than silently widening to
owner-only; for a destructive tool, failing the call beats falling back to "every
job the user owns." All four call sites propagate the error.

### Tests
The old **lexical** `strings.Contains` tests (which structurally cannot catch this
class, and let it in) are replaced with **semantic** tests that evaluate the
scoped constraint against other owners' ads through the real classad engine — a
battery of injection strings that must be rejected, benign filters that must still
self-scope, and `classadBalanced` accept/reject. Full httpserver suite green
(one unrelated pre-existing `TestGetDefaultDBPath` env failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Also in this PR: owner-scope the bulk delete/edit HTTP endpoints

The audit's separate (non-injection) finding: `handleBulkDeleteJobs` /
`handleBulkEditJobs` passed the raw request-body `constraint` to the schedd with
**no owner scoping**, while the adjacent read endpoint self-scopes non-admin Web
UI sessions. Per maintainer decision, these are now owner-scoped too:
`bulkOwnerScope` mirrors the read path's `ownedByMe` logic — a non-admin Web UI
session is confined to its own jobs; **admins bypass** (`isWebUIAdmin`), and
non-session API-token callers pass through to the schedd ACL unchanged (no
breakage for service integrations). The constraint is wrapped with the same
injection-safe `scopeToOwner`. Tested across all four branches.
