### PR TITLE
droppriv: StartAsUser — launch a subprocess as an unprivileged user

### DIFF
--- a/droppriv/launch.go
+++ b/droppriv/launch.go
@@ -1,0 +1,37 @@
+package droppriv
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// StartAsUser starts cmd with the child process running as userName (its uid/gid) -- so a daemon
+// can launch a supervised subprocess under an unprivileged account (e.g. "nobody"). It reuses
+// the package's per-thread root elevation: only the forking thread briefly regains root, just
+// long enough for the child to setuid to the target user, then the thread's credentials are
+// restored. The rest of the process never runs as root.
+//
+// It starts cmd as the current user (no drop) when userName is "" or when the process is not
+// privileged to change the child's user (a development/unprivileged run). "root" and "condor"
+// are rejected (validateUsername) -- use the manager's own facilities for those.
+//
+// The caller sets everything else on cmd (Args, Env, Stdin/out/err, Dir) as usual; StartAsUser
+// only sets SysProcAttr.Credential. cmd.Wait is the caller's responsibility.
+func (m *Manager) StartAsUser(userName string, cmd *exec.Cmd) error {
+	if strings.TrimSpace(userName) == "" {
+		return cmd.Start()
+	}
+	if err := validateUsername(userName); err != nil {
+		return err
+	}
+	target, err := m.resolveUser(userName)
+	if err != nil {
+		return err
+	}
+	return startAsUser(target, cmd)
+}
+
+// StartAsUser is the package-level helper delegating to the default Manager.
+func StartAsUser(userName string, cmd *exec.Cmd) error {
+	return DefaultManager().StartAsUser(userName, cmd)
+}

--- a/droppriv/launch_linux.go
+++ b/droppriv/launch_linux.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package droppriv
+
+import (
+	"os/exec"
+	"runtime"
+	"syscall"
+)
+
+// startAsUser starts cmd with the child dropped to target. It elevates euid to 0 on ONLY the
+// forking (locked) OS thread across the fork -- exactly as withRoot does for in-process work --
+// so the child inherits the privilege to setuid/setgid to target, then the thread's credentials
+// are restored. If the process cannot regain root (unprivileged run), cmd is started as the
+// current user (best effort), matching withRoot's fallback.
+func startAsUser(target Identity, cmd *exec.Cmd) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	state, err := captureThreadCredentials()
+	if err != nil {
+		return cmd.Start() // cannot inspect thread credentials: run as the current user
+	}
+	if err := elevateToRoot(state); err != nil {
+		_ = restoreThreadCredentials(state)
+		return cmd.Start() // not privileged to regain root: run as the current user
+	}
+	setChildCredential(cmd, target)
+	startErr := cmd.Start()
+	restoreErr := restoreThreadCredentials(state)
+	if startErr != nil {
+		return startErr
+	}
+	return restoreErr
+}
+
+// setChildCredential makes the forked child setgid/setuid to target before exec. Leaving
+// Credential.Groups nil with NoSetGroups false makes the child also drop supplementary groups
+// (setgroups to the empty set), so it runs with exactly target's uid/gid.
+func setChildCredential(cmd *exec.Cmd, target Identity) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: target.UID, Gid: target.GID}
+}

--- a/droppriv/launch_other.go
+++ b/droppriv/launch_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package droppriv
+
+import "os/exec"
+
+// startAsUser on non-Linux platforms starts cmd as the current user; setuid-to-user launching
+// relies on the Linux privilege model the daemon runs under in production.
+func startAsUser(_ Identity, cmd *exec.Cmd) error {
+	return cmd.Start()
+}

--- a/droppriv/launch_privileged_test.go
+++ b/droppriv/launch_privileged_test.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package droppriv
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+)
+
+// TestStartAsUserDropsToNobody verifies that, running as root, StartAsUser actually launches the
+// child as the target user (nobody) -- not as root -- while the parent process stays root.
+func TestStartAsUserDropsToNobody(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root privileges")
+	}
+	target, err := LookupUser(context.Background(), "nobody")
+	if err != nil {
+		t.Skipf("could not resolve nobody: %v", err)
+	}
+	uid, err := runIDU(t, "nobody")
+	if err != nil {
+		t.Fatalf("StartAsUser(nobody): %v", err)
+	}
+	if uid == "0" {
+		t.Fatal("child ran as root, not nobody")
+	}
+	if uid != strconv.Itoa(int(target.UID)) {
+		t.Errorf("child uid = %s, want nobody %d", uid, target.UID)
+	}
+	// The parent (this process) must remain root -- the elevation is thread-local and restored.
+	if os.Geteuid() != 0 {
+		t.Errorf("parent euid = %d after launch, want 0 (elevation leaked)", os.Geteuid())
+	}
+}

--- a/droppriv/launch_test.go
+++ b/droppriv/launch_test.go
@@ -1,0 +1,59 @@
+package droppriv
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+)
+
+// runIDU starts `id -u` as userName via StartAsUser and returns the child's printed uid.
+func runIDU(t *testing.T, userName string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("id", "-u")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := StartAsUser(userName, cmd); err != nil {
+		return "", err
+	}
+	if err := cmd.Wait(); err != nil {
+		return "", err
+	}
+	return string(bytes.TrimSpace(out.Bytes())), nil
+}
+
+func TestStartAsUserEmptyRunsAsSelf(t *testing.T) {
+	uid, err := runIDU(t, "")
+	if err != nil {
+		t.Fatalf("StartAsUser(\"\"): %v", err)
+	}
+	if uid != strconv.Itoa(os.Getuid()) {
+		t.Errorf("child uid = %s, want self %d", uid, os.Getuid())
+	}
+}
+
+func TestStartAsUserRejectsPrivilegedNames(t *testing.T) {
+	if err := StartAsUser("root", exec.Command("true")); err == nil {
+		t.Error("StartAsUser(\"root\") should be rejected")
+	}
+	if err := StartAsUser("condor", exec.Command("true")); err == nil {
+		t.Error("StartAsUser(\"condor\") should be rejected")
+	}
+}
+
+// TestStartAsUserUnprivilegedFallsBackToSelf: when the process can't regain root, a drop request
+// is honored best-effort by running the child as the current user (Start still succeeds).
+func TestStartAsUserUnprivilegedFallsBackToSelf(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("covered by the privileged test when running as root")
+	}
+	uid, err := runIDU(t, "nobody")
+	if err != nil {
+		t.Skipf("could not run child as nobody (user may be absent): %v", err)
+	}
+	if uid != strconv.Itoa(os.Getuid()) {
+		t.Errorf("unprivileged fallback ran child as uid %s, want self %d", uid, os.Getuid())
+	}
+}

--- a/droppriv/launch_test.go
+++ b/droppriv/launch_test.go
@@ -2,6 +2,7 @@ package droppriv
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"strconv"
@@ -11,7 +12,7 @@ import (
 // runIDU starts `id -u` as userName via StartAsUser and returns the child's printed uid.
 func runIDU(t *testing.T, userName string) (string, error) {
 	t.Helper()
-	cmd := exec.Command("id", "-u")
+	cmd := exec.CommandContext(context.Background(), "id", "-u")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = os.Stderr
@@ -35,10 +36,10 @@ func TestStartAsUserEmptyRunsAsSelf(t *testing.T) {
 }
 
 func TestStartAsUserRejectsPrivilegedNames(t *testing.T) {
-	if err := StartAsUser("root", exec.Command("true")); err == nil {
+	if err := StartAsUser("root", exec.CommandContext(context.Background(), "true")); err == nil {
 		t.Error("StartAsUser(\"root\") should be rejected")
 	}
-	if err := StartAsUser("condor", exec.Command("true")); err == nil {
+	if err := StartAsUser("condor", exec.CommandContext(context.Background(), "true")); err == nil {
 		t.Error("StartAsUser(\"condor\") should be rejected")
 	}
 }


### PR DESCRIPTION
The package could `Open`/`MkdirAll`/`Chown` as a user and run funcs as condor/root, but had no way to launch a **subprocess** as a target user — what a daemon needs to supervise a helper process off root. `StartAsUser` fills that gap, **reusing the same per-thread elevation** the `*AsRoot` helpers use (`captureThreadCredentials`/`elevateToRoot`/`restoreThreadCredentials`): it elevates euid to 0 on **only the forking (locked) thread** across the fork, so the child inherits root just long enough to setuid/setgid to the target, then the thread is restored — the rest of the process never runs as root.

It starts the child as the current user (no drop) when the name is empty or the process is not privileged to regain root (dev/unprivileged), mirroring `withRoot`'s best-effort fallback. `root`/`condor` are rejected (`validateUsername`).

## Tests
- empty name / unprivileged fallback run the child as self;
- `root`/`condor` are rejected;
- a **root-gated** test confirms the child actually runs as `nobody` while the parent stays root (thread-local elevation, restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)