### PR TITLE
config: _CONDOR_ env vars override config files, matching condor_config_val

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1117,20 +1117,27 @@ func (c *Config) parseLine(line string) error {
 	return nil
 }
 
-// LoadFromEnvironment loads configuration from the process environment
+// LoadFromEnvironment loads configuration from the process environment.
+//
+// The configuration file chain is read first, then _CONDOR_<PARAM> environment
+// overrides are applied LAST so they win over any file value. This matches
+// condor_config's real_config, which inserts environment macros only after the
+// global config source, LOCAL_CONFIG_DIR (config.d), and LOCAL_CONFIG_FILE have
+// all been processed: an env var therefore overrides a configuration file, not
+// the other way around, and env vars do not influence which files are read.
 func (c *Config) LoadFromEnvironment() error {
-	// Look for _CONDOR_ prefixed environment variables
-	for _, env := range os.Environ() {
-		if strings.HasPrefix(env, "_CONDOR_") || strings.HasPrefix(env, "_condor_") {
-			parts := strings.SplitN(env, "=", 2)
-			if len(parts) == 2 {
-				key := strings.TrimPrefix(parts[0], "_CONDOR_")
-				key = strings.TrimPrefix(key, "_condor_")
-				c.Set(key, parts[1])
-			}
-		}
+	if err := c.loadConfigFileChain(); err != nil {
+		return err
 	}
+	c.applyCondorEnvOverrides()
+	return nil
+}
 
+// loadConfigFileChain reads the root configuration file (CONDOR_CONFIG or a
+// default location) followed by the local configuration chain. It is a no-op
+// when CONDOR_CONFIG is "ONLY_ENV" or no root config file can be found; in both
+// cases the caller still applies the environment overrides afterward.
+func (c *Config) loadConfigFileChain() error {
 	// Locate the root configuration file: CONDOR_CONFIG, or a default location.
 	rootPath := os.Getenv("CONDOR_CONFIG")
 	if rootPath == "ONLY_ENV" {
@@ -1165,6 +1172,23 @@ func (c *Config) LoadFromEnvironment() error {
 		return err
 	}
 	return c.processLocalConfigFile()
+}
+
+// applyCondorEnvOverrides applies _CONDOR_<PARAM> (and _condor_<param>)
+// environment variables as configuration overrides. In HTCondor these have the
+// highest precedence -- they override values from every configuration file --
+// so this must run after the file chain has been read.
+func (c *Config) applyCondorEnvOverrides() {
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "_CONDOR_") || strings.HasPrefix(env, "_condor_") {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				key := strings.TrimPrefix(parts[0], "_CONDOR_")
+				key = strings.TrimPrefix(key, "_condor_")
+				c.Set(key, parts[1])
+			}
+		}
+	}
 }
 
 // parseConfigFile opens and parses a single configuration file at path.

--- a/config/env_override_test.go
+++ b/config/env_override_test.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCondorEnvOverridesConfigFile is the regression guard for issue #168: a
+// _CONDOR_<PARAM> environment variable must override the value of <PARAM> read
+// from the on-disk configuration, matching condor_config_val. condor_config's
+// real_config inserts environment macros only after every configuration file has
+// been processed, so an env var has higher precedence than a config file.
+func TestCondorEnvOverridesConfigFile(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "condor_config")
+	body := "SHARED_PORT_PORT = 9620\nONLY_IN_FILE = fromfile\n"
+	if err := os.WriteFile(root, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CONDOR_CONFIG", root)
+	t.Setenv("_CONDOR_SHARED_PORT_PORT", "9621")
+
+	cfg, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if got, _ := cfg.Get("SHARED_PORT_PORT"); got != "9621" {
+		t.Errorf("Get(SHARED_PORT_PORT) = %q, want 9621 (env must override the config file)", got)
+	}
+	// A param the environment does not set must still come from the file.
+	if got, _ := cfg.Get("ONLY_IN_FILE"); got != "fromfile" {
+		t.Errorf("Get(ONLY_IN_FILE) = %q, want fromfile", got)
+	}
+}
+
+// TestCondorEnvOverridesConfigDir confirms the env override also beats a value
+// set in the LOCAL_CONFIG_DIR (config.d) chain, not just the root config -- the
+// env macros are applied after the whole file chain, including config.d.
+func TestCondorEnvOverridesConfigDir(t *testing.T) {
+	tmp := t.TempDir()
+	confd := filepath.Join(tmp, "config.d")
+	if err := os.MkdirAll(confd, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(tmp, "condor_config")
+	if err := os.WriteFile(root, []byte("LOCAL_CONFIG_DIR = "+confd+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confd, "50-port.config"),
+		[]byte("SHARED_PORT_PORT = 9620\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CONDOR_CONFIG", root)
+	t.Setenv("_CONDOR_SHARED_PORT_PORT", "9621")
+
+	cfg, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got, _ := cfg.Get("SHARED_PORT_PORT"); got != "9621" {
+		t.Errorf("Get(SHARED_PORT_PORT) = %q, want 9621 (env must override config.d)", got)
+	}
+}
+
+// TestCondorEnvLocalConfigDirOverridesValueButNotScan pins the asymmetric
+// behavior of _condor_LOCAL_CONFIG_DIR, which matches condor_config's
+// real_config: environment macros are inserted only AFTER the config.d scan has
+// already run, so a _CONDOR_LOCAL_CONFIG_DIR env var overrides the *value* of
+// LOCAL_CONFIG_DIR but does NOT cause the directory it names to be scanned. The
+// directory actually scanned is the one the config *files* named.
+//
+//   - fileConfd  is named by the root config's LOCAL_CONFIG_DIR -> IS scanned
+//   - envConfd   is named only by _CONDOR_LOCAL_CONFIG_DIR      -> is NOT scanned
+func TestCondorEnvLocalConfigDirOverridesValueButNotScan(t *testing.T) {
+	tmp := t.TempDir()
+	fileConfd := filepath.Join(tmp, "file.d")
+	envConfd := filepath.Join(tmp, "env.d")
+	for _, d := range []string{fileConfd, envConfd} {
+		if err := os.MkdirAll(d, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	root := filepath.Join(tmp, "condor_config")
+	if err := os.WriteFile(root, []byte("LOCAL_CONFIG_DIR = "+fileConfd+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A marker in each directory's config.d, so we can tell which was scanned.
+	if err := os.WriteFile(filepath.Join(fileConfd, "50-x.config"),
+		[]byte("FROM_FILE_DIR = yes\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(envConfd, "50-y.config"),
+		[]byte("FROM_ENV_DIR = yes\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CONDOR_CONFIG", root)
+	t.Setenv("_CONDOR_LOCAL_CONFIG_DIR", envConfd)
+
+	cfg, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// The env var overrides the VALUE of LOCAL_CONFIG_DIR...
+	if got, _ := cfg.Get("LOCAL_CONFIG_DIR"); got != envConfd {
+		t.Errorf("Get(LOCAL_CONFIG_DIR) = %q, want %q (env overrides the value)", got, envConfd)
+	}
+	// ...but the directory that was actually SCANNED is the file-configured one
+	// (the env var comes too late to influence the scan).
+	if got, _ := cfg.Get("FROM_FILE_DIR"); got != "yes" {
+		t.Errorf("Get(FROM_FILE_DIR) = %q, want yes: the file-configured config.d must still be scanned", got)
+	}
+	// The env-named directory must NOT have been scanned.
+	if got, ok := cfg.Get("FROM_ENV_DIR"); ok && got != "" {
+		t.Errorf("Get(FROM_ENV_DIR) = %q: the _CONDOR_LOCAL_CONFIG_DIR directory must NOT be scanned", got)
+	}
+}
+
+// TestCondorEnvOverrideAppliesWithoutConfigFile guards the ONLY_ENV path: env
+// overrides must still be applied when no configuration file is read, since they
+// are applied after the (here empty) file chain rather than before it.
+func TestCondorEnvOverrideAppliesWithoutConfigFile(t *testing.T) {
+	t.Setenv("CONDOR_CONFIG", "ONLY_ENV")
+	t.Setenv("_CONDOR_SHARED_PORT_PORT", "9622")
+
+	cfg, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got, _ := cfg.Get("SHARED_PORT_PORT"); got != "9622" {
+		t.Errorf("Get(SHARED_PORT_PORT) = %q, want 9622 (env must apply even with ONLY_ENV)", got)
+	}
+}


### PR DESCRIPTION
`config.New()` gave on-disk config priority over `_CONDOR_<PARAM>` environment variables, so a value in `config.d` overrode the env var — the reverse of `condor_config_val`.

condor_config's `real_config` inserts environment macros only after the global config, `LOCAL_CONFIG_DIR` (config.d), and `LOCAL_CONFIG_FILE` are processed, so an env var has higher precedence than any configuration file. `LoadFromEnvironment` now reads the file chain first and applies `_CONDOR_*` overrides last.

This also matches the C++ asymmetry for `_CONDOR_LOCAL_CONFIG_DIR`: it overrides the *value* of `LOCAL_CONFIG_DIR` but does not redirect the config.d scan, which has already run by the time env macros are applied. A regression test pins that behavior.

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)