### PR TITLE
config: honor directories appended to LOCAL_CONFIG_DIR by a config file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1182,83 +1182,108 @@ func (c *Config) parseConfigFile(path string) (err error) {
 	return c.parseReader(f, path)
 }
 
-// processLocalConfigDir processes directories listed in LOCAL_CONFIG_DIR
-// Directories are processed left-to-right, files within each directory are
-// processed in lexicographical order
+// processLocalConfigDir processes directories listed in LOCAL_CONFIG_DIR.
+// Directories are processed left-to-right, files within each directory in
+// lexicographic order.
+//
+// A config file inside a scanned directory may itself append to LOCAL_CONFIG_DIR
+// (for example LOCAL_CONFIG_DIR = $(LOCAL_CONFIG_DIR),/extra/dir). After each
+// pass we re-read the list and scan any directory not scanned yet, matching
+// condor_config's real_config, which re-processes LOCAL_CONFIG_DIR when a config
+// file changed it. Already-scanned directories are tracked so their files are
+// not re-parsed (which would re-apply a self-referential append), and the number
+// of passes is bounded so a config that keeps appending cannot loop forever.
 func (c *Config) processLocalConfigDir() error {
-	dirList, ok := c.Get("LOCAL_CONFIG_DIR")
-	if !ok || dirList == "" {
-		return nil
-	}
-
-	// Split on comma and/or space
-	dirs := SplitConfigList(dirList)
-
-	// Files whose basename matches LOCAL_CONFIG_DIR_EXCLUDE_REGEXP are skipped --
-	// this is how HTCondor keeps editor backups, package leftovers (.rpmnew,
-	// .dpkg-dist), and helper scripts (.py/.sh/.pl) out of config.d parsing. A
-	// config.d without this filter would try to parse those as config and fail or
-	// mis-set values.
-	var excludeRe *regexp.Regexp
-	if pat, ok := c.Get("LOCAL_CONFIG_DIR_EXCLUDE_REGEXP"); ok && pat != "" {
-		if re, err := regexp.Compile(pat); err == nil {
-			excludeRe = re
-		}
-	}
-
-	for _, dir := range dirs {
-		dir = strings.TrimSpace(dir)
-		if dir == "" {
-			continue
+	scanned := make(map[string]bool)
+	// Real configurations converge in one or two passes; the bound only guards a
+	// pathological config that appends a fresh directory on every pass.
+	const maxPasses = 128
+	for pass := 0; pass < maxPasses; pass++ {
+		dirList, ok := c.Get("LOCAL_CONFIG_DIR")
+		if !ok || dirList == "" {
+			return nil
 		}
 
-		// Check if directory exists
-		info, err := os.Stat(dir)
+		// Files whose basename matches LOCAL_CONFIG_DIR_EXCLUDE_REGEXP are skipped --
+		// this is how HTCondor keeps editor backups, package leftovers (.rpmnew,
+		// .dpkg-dist), and helper scripts (.py/.sh/.pl) out of config.d parsing. A
+		// config.d without this filter would try to parse those as config and fail
+		// or mis-set values. Re-read each pass since a config file may set it.
+		var excludeRe *regexp.Regexp
+		if pat, ok := c.Get("LOCAL_CONFIG_DIR_EXCLUDE_REGEXP"); ok && pat != "" {
+			if re, err := regexp.Compile(pat); err == nil {
+				excludeRe = re
+			}
+		}
+
+		progressed := false
+		for _, dir := range SplitConfigList(dirList) {
+			dir = strings.TrimSpace(dir)
+			if dir == "" {
+				continue
+			}
+			dir = filepath.Clean(dir)
+			if scanned[dir] {
+				continue // already scanned on an earlier pass
+			}
+			scanned[dir] = true
+			progressed = true
+			if err := c.scanConfigDir(dir, excludeRe); err != nil {
+				return err
+			}
+		}
+		if !progressed {
+			// No directory appeared that we had not already scanned: converged.
+			return nil
+		}
+	}
+	return nil
+}
+
+// scanConfigDir parses every eligible configuration file in a single directory,
+// in lexicographic order. A non-existent directory or a non-directory path is
+// skipped; a file whose basename matches excludeRe is skipped.
+func (c *Config) scanConfigDir(dir string, excludeRe *regexp.Regexp) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // Skip non-existent directories
+		}
+		return fmt.Errorf("error accessing directory %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil // Skip non-directories
+	}
+
+	// os.ReadDir returns entries sorted by filename (lexicographic order).
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("error reading directory %s: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue // Skip subdirectories
+		}
+		if excludeRe != nil && excludeRe.MatchString(entry.Name()) {
+			continue // Excluded by LOCAL_CONFIG_DIR_EXCLUDE_REGEXP
+		}
+
+		filePath := filepath.Join(dir, entry.Name())
+		// Open and parse the file
+		//nolint:gosec // G304: Config directory path comes from validated configuration
+		f, err := os.Open(filePath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				continue // Skip non-existent directories
-			}
-			return fmt.Errorf("error accessing directory %s: %w", dir, err)
+			return fmt.Errorf("error opening %s: %w", filePath, err)
 		}
-
-		if !info.IsDir() {
-			continue // Skip non-directories
+		err = c.parseAndExecute(f)
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("failed to close file: %w", cerr)
 		}
-
-		// Read directory entries
-		entries, err := os.ReadDir(dir)
 		if err != nil {
-			return fmt.Errorf("error reading directory %s: %w", dir, err)
-		}
-
-		// Sort entries lexicographically (ReadDir already returns sorted)
-		for _, entry := range entries {
-			if entry.IsDir() {
-				continue // Skip subdirectories
-			}
-			if excludeRe != nil && excludeRe.MatchString(entry.Name()) {
-				continue // Excluded by LOCAL_CONFIG_DIR_EXCLUDE_REGEXP
-			}
-
-			filePath := filepath.Join(dir, entry.Name())
-
-			// Open and parse the file
-			//nolint:gosec // G304: Config directory path comes from validated configuration
-			f, err := os.Open(filePath)
-			if err != nil {
-				return fmt.Errorf("error opening %s: %w", filePath, err)
-			}
-			err = c.parseAndExecute(f)
-			if cerr := f.Close(); cerr != nil && err == nil {
-				err = fmt.Errorf("failed to close file: %w", cerr)
-			}
-
-			if err != nil {
-				return fmt.Errorf("error parsing %s: %w", filePath, err)
-			}
+			return fmt.Errorf("error parsing %s: %w", filePath, err)
 		}
 	}
-
 	return nil
 }
 

--- a/config/local_config_dir_rescan_test.go
+++ b/config/local_config_dir_rescan_test.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mkdirs is a small helper that creates each directory (and parents).
+func mkdirs(t *testing.T, dirs ...string) {
+	t.Helper()
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// writeFile is a small helper that writes a config file.
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestLocalConfigDirSelfAppendScanned is the regression guard for issue #169: a
+// config file that appends a directory to LOCAL_CONFIG_DIR
+// (LOCAL_CONFIG_DIR = $(LOCAL_CONFIG_DIR),/extra) must cause that directory to be
+// scanned. Previously LOCAL_CONFIG_DIR was read once and the appended directory
+// was silently ignored, unlike condor_config_val.
+func TestLocalConfigDirSelfAppendScanned(t *testing.T) {
+	tmp := t.TempDir()
+	dirA := filepath.Join(tmp, "a.d")
+	dirB := filepath.Join(tmp, "b.d")
+	mkdirs(t, dirA, dirB)
+
+	root := filepath.Join(tmp, "condor_config")
+	writeFile(t, root, "LOCAL_CONFIG_DIR = "+dirA+"\n")
+	// A file in the initially-scanned dir appends a second directory.
+	writeFile(t, filepath.Join(dirA, "20-append.conf"),
+		"FROM_DIR_A = yes\nLOCAL_CONFIG_DIR = $(LOCAL_CONFIG_DIR),"+dirB+"\n")
+	// The appended directory carries the value the daemon must pick up.
+	writeFile(t, filepath.Join(dirB, "50-port.conf"),
+		"FROM_APPENDED_DIR = yes\nSHARED_PORT_PORT = 9620\n")
+
+	t.Setenv("CONDOR_CONFIG", root)
+	cfg, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	for key, want := range map[string]string{
+		"FROM_DIR_A":        "yes",  // the initial dir was scanned
+		"FROM_APPENDED_DIR": "yes",  // the appended dir was scanned (the bug)
+		"SHARED_PORT_PORT":  "9620", // ...and its values took effect
+	} {
+		if got, _ := cfg.Get(key); got != want {
+			t.Errorf("Get(%q) = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// TestLocalConfigDirAppendChainMultiLevel covers an append chain deeper than one
+// level (a -> b -> c): each newly scanned directory appends the next. This needs
+// more than a single re-scan, so it exercises the loop-until-converged behavior
+// (stricter than condor_config's single re-check).
+func TestLocalConfigDirAppendChainMultiLevel(t *testing.T) {
+	tmp := t.TempDir()
+	dirA := filepath.Join(tmp, "a.d")
+	dirB := filepath.Join(tmp, "b.d")
+	dirC := filepath.Join(tmp, "c.d")
+	mkdirs(t, dirA, dirB, dirC)
+
+	root := filepath.Join(tmp, "condor_config")
+	writeFile(t, root, "LOCAL_CONFIG_DIR = "+dirA+"\n")
+	writeFile(t, filepath.Join(dirA, "20.conf"), "LOCAL_CONFIG_DIR = $(LOCAL_CONFIG_DIR),"+dirB+"\n")
+	writeFile(t, filepath.Join(dirB, "20.conf"), "LOCAL_CONFIG_DIR = $(LOCAL_CONFIG_DIR),"+dirC+"\n")
+	writeFile(t, filepath.Join(dirC, "50.conf"), "FROM_DIR_C = yes\n")
+
+	t.Setenv("CONDOR_CONFIG", root)
+	cfg, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got, _ := cfg.Get("FROM_DIR_C"); got != "yes" {
+		t.Errorf("Get(FROM_DIR_C) = %q, want yes: a multi-level append chain was not fully followed", got)
+	}
+}
+
+// TestLocalConfigDirRescanPicksUpFileAddedLater mirrors the issue's exact flow:
+// a daemon starts, then a file is dropped into the appended directory, then the
+// config is reloaded. A fresh load (as a reconfig performs) must see the new
+// file. The first load sees the appended directory empty; the second sees the
+// added file.
+func TestLocalConfigDirRescanPicksUpFileAddedLater(t *testing.T) {
+	tmp := t.TempDir()
+	dirA := filepath.Join(tmp, "a.d")
+	dirB := filepath.Join(tmp, "b.d") // the daemon-owned drop directory
+	mkdirs(t, dirA, dirB)
+
+	root := filepath.Join(tmp, "condor_config")
+	writeFile(t, root, "LOCAL_CONFIG_DIR = "+dirA+"\n")
+	writeFile(t, filepath.Join(dirA, "20-append.conf"),
+		"LOCAL_CONFIG_DIR = $(LOCAL_CONFIG_DIR),"+dirB+"\n")
+
+	t.Setenv("CONDOR_CONFIG", root)
+
+	// First load: the appended directory exists but is empty.
+	cfg1, err := New()
+	if err != nil {
+		t.Fatalf("New (initial): %v", err)
+	}
+	if _, ok := cfg1.Get("DROPPED_LATER"); ok {
+		t.Fatal("DROPPED_LATER unexpectedly set before the file existed")
+	}
+
+	// Drop a config file into the appended directory (as the daemon would).
+	writeFile(t, filepath.Join(dirB, "50-dropped.conf"), "DROPPED_LATER = yes\n")
+
+	// Reload: a fresh load must now pick up the dropped file.
+	cfg2, err := New()
+	if err != nil {
+		t.Fatalf("New (reload): %v", err)
+	}
+	if got, _ := cfg2.Get("DROPPED_LATER"); got != "yes" {
+		t.Errorf("Get(DROPPED_LATER) = %q, want yes: reload did not scan the appended directory", got)
+	}
+}
+
+// TestLocalConfigDirSelfAppendTerminates guards termination: a file that appends
+// its OWN directory must not cause the scan to loop forever. The directory is
+// scanned once (already-scanned directories are skipped) and loading completes.
+func TestLocalConfigDirSelfAppendTerminates(t *testing.T) {
+	tmp := t.TempDir()
+	dirA := filepath.Join(tmp, "a.d")
+	mkdirs(t, dirA)
+
+	root := filepath.Join(tmp, "condor_config")
+	writeFile(t, root, "LOCAL_CONFIG_DIR = "+dirA+"\n")
+	writeFile(t, filepath.Join(dirA, "20.conf"),
+		"MARKER = yes\nLOCAL_CONFIG_DIR = $(LOCAL_CONFIG_DIR),"+dirA+"\n")
+
+	t.Setenv("CONDOR_CONFIG", root)
+	cfg, err := New() // must return, not hang
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got, _ := cfg.Get("MARKER"); got != "yes" {
+		t.Errorf("Get(MARKER) = %q, want yes", got)
+	}
+}


### PR DESCRIPTION
`processLocalConfigDir` read `LOCAL_CONFIG_DIR` once, so a directory a scanned config file *appended* — `LOCAL_CONFIG_DIR = $(LOCAL_CONFIG_DIR),/usr/share/condor/daemon-config.d/` — was silently ignored, even though `condor_config_val` saw it. This is why a daemon's reconfig did not pick up config files dropped into that directory.

condor_config's `real_config` re-reads `LOCAL_CONFIG_DIR` after processing the config chain and re-scans when a config file changed it. This does the same: after each pass, re-read the list and scan any directory not yet scanned, until none remain. Already-scanned directories are tracked (so a self-referential append is not re-applied), and the passes are bounded so a config that keeps appending cannot loop forever — slightly stricter than the C++ single re-check, so a multi-level append chain is also followed.

Tests cover: the self-append repro, a multi-level append chain, a file dropped into the appended directory and picked up on a fresh (reload) load, and termination on a self-referential append.

Fixes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)