### PR TITLE
config: resolve parameter names case-insensitively

### DIFF
--- a/config/case_insensitive_test.go
+++ b/config/case_insensitive_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLookupIsCaseInsensitive covers HTCondor's rule that parameter names do
+// not distinguish case. Before this, a Config would answer only to the exact
+// spelling used in the file.
+func TestLookupIsCaseInsensitive(t *testing.T) {
+	cfg, err := NewFromReaderWithOptions(
+		strings.NewReader("PELICAN_PORT = 8444\nlower_case_knob = yes\n"),
+		ConfigOptions{SkipDefaults: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"PELICAN_PORT", "pelican_port", "Pelican_Port"} {
+		if v, ok := cfg.Get(name); !ok || v != "8444" {
+			t.Errorf("Get(%q) = %q, %v; want \"8444\", true", name, v, ok)
+		}
+	}
+	// ... and in the other direction, for a knob written in lower case.
+	for _, name := range []string{"lower_case_knob", "LOWER_CASE_KNOB"} {
+		if v, ok := cfg.Get(name); !ok || v != "yes" {
+			t.Errorf("Get(%q) = %q, %v; want \"yes\", true", name, v, ok)
+		}
+	}
+}
+
+// TestLocalNameLookupIsCaseInsensitive is the case that motivated this. A
+// daemon started with "-local-name cache_a" has to find a CACHE_A.* definition:
+// the local name arrives from the command line while the key is written in a
+// config file, and nothing makes an operator match their own capitalization.
+func TestLocalNameLookupIsCaseInsensitive(t *testing.T) {
+	const text = `
+PELICAN_PORT = 8444
+CACHE_A.PELICAN_PORT = 9444
+lower_b.PELICAN_PORT = 9555
+PELICAN.CACHE_C.PELICAN_PORT = 9666
+`
+	for _, tc := range []struct{ localName, want string }{
+		{"", "8444"},
+		{"CACHE_A", "9444"},
+		{"cache_a", "9444"}, // differs in case from the definition
+		{"lower_b", "9555"},
+		{"LOWER_B", "9555"}, // differs in case from the definition
+		{"cache_c", "9666"}, // reached through <SUBSYS>.<LOCALNAME>.<KEY>
+	} {
+		cfg, err := NewFromReaderWithOptions(strings.NewReader(text),
+			ConfigOptions{Subsystem: "PELICAN", LocalName: tc.localName, SkipDefaults: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, _ := cfg.Get("PELICAN_PORT"); got != tc.want {
+			t.Errorf("local name %q: got %s, want %s", tc.localName, got, tc.want)
+		}
+	}
+}
+
+// TestRedefinitionInDifferentCaseReplaces checks that two spellings of one knob
+// do not both survive, which would make the winner depend on map iteration
+// order.
+func TestRedefinitionInDifferentCaseReplaces(t *testing.T) {
+	cfg, err := NewFromReaderWithOptions(
+		strings.NewReader("SOME_KNOB = first\nsome_knob = second\n"),
+		ConfigOptions{SkipDefaults: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := cfg.Get("SOME_KNOB"); got != "second" {
+		t.Errorf("later definition should win regardless of case: got %q", got)
+	}
+	if n := len(cfg.values); n != 1 {
+		t.Errorf("one knob should be stored once, found %d entries: %v", n, cfg.values)
+	}
+}
+
+// TestDefinedIsCaseInsensitive covers "if defined X" in the config language.
+func TestDefinedIsCaseInsensitive(t *testing.T) {
+	cfg, err := NewFromReaderWithOptions(
+		strings.NewReader("SOME_KNOB = 1\nif defined some_knob\n  RESULT = found\nendif\n"),
+		ConfigOptions{SkipDefaults: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := cfg.Get("RESULT"); got != "found" {
+		t.Errorf("`defined` should not distinguish case: RESULT = %q", got)
+	}
+}

--- a/config/conditionals.go
+++ b/config/conditionals.go
@@ -54,14 +54,14 @@ func (c *Config) evaluateCondition(condition string) (bool, error) {
 	if strings.HasPrefix(condition, "defined(") && strings.HasSuffix(condition, ")") {
 		varName := condition[8 : len(condition)-1]
 		varName = strings.TrimSpace(varName)
-		_, ok := c.values[varName]
+		ok := c.hasKey(varName)
 		return ok, nil
 	}
 
 	// Handle "defined VAR" syntax (without parentheses)
 	if strings.HasPrefix(condition, "defined ") {
 		varName := strings.TrimSpace(condition[8:])
-		_, ok := c.values[varName]
+		ok := c.hasKey(varName)
 		return ok, nil
 	}
 
@@ -72,7 +72,11 @@ func (c *Config) evaluateCondition(condition string) (bool, error) {
 
 	// Handle boolean expressions and variable references
 	// Simple case: just a variable name that should evaluate to true/false/yes/no/1/0
-	value, ok := c.values[condition]
+	actual, ok := c.resolveKey(condition)
+	value := ""
+	if ok {
+		value = c.values[actual]
+	}
 	if ok {
 		return c.isTruthy(value), nil
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,9 @@ type ConfigOptions struct {
 // Config represents an HTCondor configuration with key-value pairs
 type Config struct {
 	values map[string]string
+	// folded maps an upper-cased key to the spelling actually stored in values,
+	// so a lookup can match the way HTCondor does: case-insensitively.
+	folded map[string]string
 	// Track macro evaluation depth to detect loops
 	evaluating map[string]bool
 	// Track included files to prevent cycles
@@ -117,6 +120,7 @@ func (c *Config) Options() ConfigOptions { return c.options }
 func NewWithOptions(opts ConfigOptions) (*Config, error) {
 	cfg := &Config{
 		values:        make(map[string]string),
+		folded:        make(map[string]string),
 		evaluating:    make(map[string]bool),
 		includedFiles: make(map[string]bool),
 		options:       opts,
@@ -158,6 +162,46 @@ func NewFromReaderWithOptions(r io.Reader, opts ConfigOptions) (*Config, error) 
 	return cfg, nil
 }
 
+// putValue stores a value, recording the key's spelling so it can later be
+// found case-insensitively.
+//
+// A knob redefined with different capitalization replaces the earlier spelling
+// rather than sitting beside it: HTCondor treats the two as one parameter, and
+// leaving both would make the winner depend on map iteration order.
+func (c *Config) putValue(key, value string) {
+	if c.folded == nil {
+		c.folded = make(map[string]string, len(c.values))
+	}
+	upper := strings.ToUpper(key)
+	if previous, ok := c.folded[upper]; ok && previous != key {
+		delete(c.values, previous)
+	}
+	c.folded[upper] = key
+	c.values[key] = value
+}
+
+// resolveKey returns the stored spelling of key, matching case-insensitively.
+//
+// HTCondor's configuration language does not distinguish case in parameter
+// names, so neither can this: a daemon given "-local-name cache_a" has to find
+// a CACHE_A.* definition, and a lookup of "pelican_port" has to find
+// PELICAN_PORT.
+func (c *Config) resolveKey(key string) (string, bool) {
+	if _, ok := c.values[key]; ok {
+		return key, true
+	}
+	if actual, ok := c.folded[strings.ToUpper(key)]; ok {
+		return actual, true
+	}
+	return "", false
+}
+
+// hasKey reports whether a parameter is defined, case-insensitively.
+func (c *Config) hasKey(key string) bool {
+	_, ok := c.resolveKey(key)
+	return ok
+}
+
 // Get retrieves a configuration value, honoring HTCondor's subsystem and
 // local-name prefix precedence. For a Config created with a Subsystem and/or
 // LocalName, a more specific definition overrides the bare parameter, most
@@ -180,10 +224,11 @@ func (c *Config) Get(key string) (string, bool) {
 
 	key = c.scopedLookupKey(key)
 
-	val, ok := c.values[key]
+	actual, ok := c.resolveKey(key)
 	if !ok {
 		return "", false
 	}
+	val := c.values[actual]
 
 	// Expand macros and function macros in the value
 	expanded, err := c.expandMacrosWithFunctions(val)
@@ -207,17 +252,17 @@ func (c *Config) scopedLookupKey(key string) string {
 	}
 	// Most specific first; only override when a scoped definition actually exists.
 	if subsys != "" && local != "" {
-		if _, ok := c.values[subsys+"."+local+"."+key]; ok {
+		if c.hasKey(subsys + "." + local + "." + key) {
 			return subsys + "." + local + "." + key
 		}
 	}
 	if local != "" {
-		if _, ok := c.values[local+"."+key]; ok {
+		if c.hasKey(local + "." + key) {
 			return local + "." + key
 		}
 	}
 	if subsys != "" {
-		if _, ok := c.values[subsys+"."+key]; ok {
+		if c.hasKey(subsys + "." + key) {
 			return subsys + "." + key
 		}
 	}
@@ -229,7 +274,8 @@ func (c *Config) Set(key, value string) {
 	// Check if this is a self-referential definition
 	if strings.Contains(value, "$("+key+")") {
 		// Expand the self-reference immediately
-		if oldVal, ok := c.values[key]; ok {
+		if actual, ok := c.resolveKey(key); ok {
+			oldVal := c.values[actual]
 			value = strings.ReplaceAll(value, "$("+key+")", oldVal)
 		} else {
 			// First definition, just remove the self-reference
@@ -237,7 +283,7 @@ func (c *Config) Set(key, value string) {
 		}
 	}
 
-	c.values[key] = value
+	c.putValue(key, value)
 }
 
 // Keys returns all configuration keys
@@ -260,7 +306,7 @@ func (c *Config) initBuiltins() {
 			defaultVal = pd.Win32Default
 		}
 		// Set the value (unexpanded - will be expanded on Get())
-		c.values[pd.Name] = defaultVal
+		c.putValue(pd.Name, defaultVal)
 	}
 
 	// Apply hand-curated overrides from param_overrides.go. These
@@ -270,7 +316,7 @@ func (c *Config) initBuiltins() {
 	// win, BEFORE any CONDOR_CONFIG file load so user values still win
 	// over them.
 	for _, po := range paramOverrides {
-		c.values[po.Name] = po.Default
+		c.putValue(po.Name, po.Default)
 	}
 
 	// Time constants (these override param defaults)
@@ -919,13 +965,13 @@ func (c *Config) expandMacros(value string) (string, error) {
 		}
 
 		// Check for circular reference
-		if c.evaluating[varName] {
+		if c.evaluating[strings.ToUpper(varName)] {
 			// Skip this macro to avoid infinite loop
 			result = result[:dollarIdx] + "$(" + varName + ")" + result[endIdx+1:]
 			break
 		}
 
-		c.evaluating[varName] = true
+		c.evaluating[strings.ToUpper(varName)] = true
 
 		// Get value. Resolve through the subsystem/local-name scoping that Get()
 		// uses, so `$(IsMaster)` under SUBSYSTEM=MASTER expands via MASTER.IsMaster,
@@ -936,7 +982,7 @@ func (c *Config) expandMacros(value string) (string, error) {
 			replacement = val
 		}
 
-		delete(c.evaluating, varName)
+		delete(c.evaluating, strings.ToUpper(varName))
 
 		// Replace the macro with its value
 		result = result[:dollarIdx] + replacement + result[endIdx+1:]

--- a/config/functions.go
+++ b/config/functions.go
@@ -356,11 +356,11 @@ func (c *Config) expandMacrosWithFunctions(value string) (string, error) {
 					}
 
 					// Check for circular reference
-					if c.evaluating[varName] {
+					if c.evaluating[strings.ToUpper(varName)] {
 						return result, fmt.Errorf("circular reference detected: %s", varName)
 					}
 
-					c.evaluating[varName] = true
+					c.evaluating[strings.ToUpper(varName)] = true
 					// Resolve through subsystem/local-name scoping (as Get does), so
 					// `$(IsMaster)` under SUBSYSTEM=MASTER expands via MASTER.IsMaster
 					// and any `$(KNOB)` honors a `SUBSYS.KNOB` override, matching
@@ -369,7 +369,7 @@ func (c *Config) expandMacrosWithFunctions(value string) (string, error) {
 					if !ok {
 						replacement = defaultVal
 					}
-					delete(c.evaluating, varName)
+					delete(c.evaluating, strings.ToUpper(varName))
 
 					result = result[:dollarIdx] + replacement + result[endIdx+1:]
 					changed = true


### PR DESCRIPTION
## What

`Config` resolved parameter names case-sensitively, while HTCondor's configuration language does not distinguish case. `Get("pelican_port")` missed a `PELICAN_PORT` definition, and `if defined some_knob` did not see `SOME_KNOB`.

## Why it matters

The case that surfaced this is local-name scoping, where the consequence is silent rather than an error.

A daemon started with `-local-name cache_a` resolves knobs through `<LOCALNAME>.<KEY>` before the bare name. But the local name arrives on the command line while the key is written in a config file, and nothing obliges an operator to match their own capitalization:

```
PELICAN_PORT          = 8444
CACHE_A.PELICAN_PORT  = 9444
```

Started with `-local-name cache_a`, the daemon read **8444** — the shared value — and came up looking healthy while using another instance's configuration. Per-instance configuration is the whole reason `-local-name` exists, so the failure is quiet and in exactly the place that is hard to notice.

Found while running `pelican-server` as a DaemonCore daemon under `condor_master`.

## How

- Keys keep the spelling they were written with; a parallel index maps the upper-cased name to it, so lookups match either way.
- Redefining a knob in different case replaces the earlier spelling instead of storing both — otherwise the winner would depend on map iteration order.
- Loop detection is normalized alongside the lookup. Without that a self-reference reached through a different spelling (`FOO = $(foo)`) recurses until the stack is exhausted, because the guard keyed on the exact name while the lookup no longer did. That showed up as a stack overflow across the existing suite, so it is not hypothetical.

## Testing

Four new tests in `config/case_insensitive_test.go`: bare lookups in either direction, local-name scoping including `<SUBSYS>.<LOCALNAME>.<KEY>`, redefinition in differing case, and `if defined`.

The existing `./config/...` suite passes unchanged. `go test -short ./...` is clean apart from `sharedport.TestListenerCloseWaitsForHandlers`, which fails identically on `main` (a macOS unix-socket path-length limit).

## Note

The consumer currently upper-cases the local name to work around this; that workaround comes out once this lands, and it is wrong in the other direction anyway — it misses a `lower_b.KNOB` definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)